### PR TITLE
Added tag inheritance policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+# [2.1.0] - 2023-12-18
+
+- Added tag inheritance policy setup
+
 # [2.0.0] - 2023-12-13
 
 Automatic domain join of windows assigned

--- a/archetypes/archetype_definition_qby_root.json
+++ b/archetypes/archetype_definition_qby_root.json
@@ -13,7 +13,8 @@
             "Deploy-Resource-Diag",
             "Deploy-VM-Monitoring",
             "Deploy-VMSS-Monitoring",
-            "Enforce-ACSB"
+            "Enforce-ACSB",
+            "QBY-Deploy-Tag-Inheritance"
         ],
         "policy_definitions": [
             "Append-AppService-httpsonly",
@@ -130,7 +131,8 @@
             "Deploy-Vm-autoShutdown",
             "Deploy-VNET-HubSpoke",
             "Deploy-Windows-DomainJoin",
-            "QBY-Deploy-VM-Backup"
+            "QBY-Deploy-VM-Backup",
+            "QBY-Deploy-Tags-To-RG"
         ],
         "policy_set_definitions": [
             "Audit-UnusedResourcesCostOptimization",
@@ -144,7 +146,8 @@
             "Enforce-ALZ-Sandbox",
             "Enforce-Encryption-CMK",
             "Enforce-EncryptTransit",
-            "Enforce-Guardrails-KeyVault"
+            "Enforce-Guardrails-KeyVault",
+            "QBY-Deploy-Tag-Inheritance"
         ],
         "role_definitions": [
             "Network-Subnet-Contributor",

--- a/archetypes/archetype_definition_qby_root.json
+++ b/archetypes/archetype_definition_qby_root.json
@@ -14,7 +14,7 @@
             "Deploy-VM-Monitoring",
             "Deploy-VMSS-Monitoring",
             "Enforce-ACSB",
-            "QBY-Deploy-Tag-Inheritance"
+            "QBY-Deploy-Tag-Structure"
         ],
         "policy_definitions": [
             "Append-AppService-httpsonly",

--- a/policy_definitions/tagging/policy_assignment_qby_deploy_tags_from_resource_group.tmpl.json
+++ b/policy_definitions/tagging/policy_assignment_qby_deploy_tags_from_resource_group.tmpl.json
@@ -1,5 +1,5 @@
 {
-    "name": "QBY-Deploy-Tag-Inheritance",
+    "name": "QBY-Deploy-Tag-Structure",
     "type": "Microsoft.Authorization/policyAssignments",
     "apiVersion": "2022-06-01",
     "dependsOn": [],

--- a/policy_definitions/tagging/policy_assignment_qby_deploy_tags_from_resource_group.tmpl.json
+++ b/policy_definitions/tagging/policy_assignment_qby_deploy_tags_from_resource_group.tmpl.json
@@ -1,0 +1,20 @@
+{
+    "name": "QBY-Deploy-Tag-Inheritance",
+    "type": "Microsoft.Authorization/policyAssignments",
+    "apiVersion": "2022-06-01",
+    "dependsOn": [],
+    "properties": {
+      "description": "Assigns the Microsoft built in policy to inherit a set of tags from a the resource group to resources if missing.",
+      "displayName": "Deploy tags from resource group to resources",
+      "enforcementMode": null,
+      "nonComplianceMessages": [],
+      "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policySetDefinitions/QBY-Deploy-Tag-Inheritance",
+      "scope": "${current_scope_resource_id}",
+      "notScopes": [],
+      "parameters": {}
+    },
+    "location": "${default_location}",
+    "identity": {
+      "type": "None"
+    }
+  }

--- a/policy_definitions/tagging/policy_assignment_qby_deploy_tags_from_resource_group.tmpl.json
+++ b/policy_definitions/tagging/policy_assignment_qby_deploy_tags_from_resource_group.tmpl.json
@@ -15,6 +15,6 @@
     },
     "location": "${default_location}",
     "identity": {
-      "type": "None"
+      "type": "SystemAssigned"
     }
   }

--- a/policy_definitions/tagging/policy_definition_qby_deploy_tags_to_resource_group.json
+++ b/policy_definitions/tagging/policy_definition_qby_deploy_tags_to_resource_group.json
@@ -1,0 +1,56 @@
+{
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "name": "QBY-Deploy-Tags-To-RG",
+    "properties": {
+        "displayName": "Deploy tags from subscription to resource groups",
+        "description": "Inherit a given tag from the subscription to resource groups if missing.",
+        "policyType": "Custom",
+        "mode": "All",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "Tags"
+        },
+        "parameters": {
+            "tagName": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Tag Name",
+                "description": "Name of the tag, such as 'environment'"
+              }
+            }
+          },
+        "policyRule": {
+            "if": {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.Resources/subscriptions/resourceGroups"
+                },
+                {
+                  "field": "[concat('tags[', parameters('tagName'), ']')]",
+                  "exists": "false"
+                },
+                {
+                  "value": "[subscription().tags[parameters('tagName')]]",
+                  "notEquals": ""
+                }
+              ]
+            },
+            "then": {
+              "effect": "modify",
+              "details": {
+                "roleDefinitionIds": [
+                  "/providers/microsoft.authorization/roleDefinitions/4a9ae827-6dc8-4573-8ac7-8239d42aa03f"
+                ],
+                "operations": [
+                  {
+                    "operation": "add",
+                    "field": "[concat('tags[', parameters('tagName'), ']')]",
+                    "value": "[subscription().tags[parameters('tagName')]]"
+                  }
+                ]
+              }
+            }
+          }
+    }
+}

--- a/policy_definitions/tagging/policy_set_definition_qby_deploy_tags_from_resource_group.tmpl.json
+++ b/policy_definitions/tagging/policy_set_definition_qby_deploy_tags_from_resource_group.tmpl.json
@@ -1,0 +1,39 @@
+{
+    "name": "QBY-Deploy-Tag-Inheritance",
+    "type": "Microsoft.Authorization/policySetDefinitions",
+    "apiVersion": "2021-06-01",
+    "scope": null,
+    "properties": {
+      "policyType": "Custom",
+      "displayName": "Deploy tags from resource group to resources",
+      "description": "Assigns the Microsoft built in policy to inherit a set of tags from a the resource group to resources if missing.",
+      "metadata": {
+        "version": "1.0.0",
+        "category": "Tags"
+      },
+      "parameters": {},
+      "policyDefinitions": ${jsonencode(flatten([for tag_name in tags: [
+        {
+            "policyDefinitionReferenceId": "Inherit '${tag_name}' tag from resource group to resources if missing",
+            "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ea3f2387-9b95-492a-a190-fcdc54f7b070",
+            "parameters": {
+                "tagName": {
+                    "value": "${tag_name}"
+                }
+            },
+            "groupNames": []
+        },
+        {
+            "policyDefinitionReferenceId": "Inherit '${tag_name}' tag from subscription to resource groups if missing",
+            "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/QBY-Deploy-Tags-To-RG",
+            "parameters": {
+                "tagName": {
+                    "value": "${tag_name}"
+                }
+            },
+            "groupNames": []
+        }
+      ]]))},
+      "policyDefinitionGroups": null
+    }
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of changes and which issues are fixed -->
<!-- Example -->

Added a policy for inheriting tags to resource groups and a policy set that combines this policy with a built in policy that inherits tags from the resource group. This allows for a tag hierarchy where the resource group level can override the subscription level tags.

This policy set is then enabled in the qby_root default archetype.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [x] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `2.0.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `2.1.0`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] This branch was deployed in our test environment (PCMS-DEV1)
- [x] Tested the policy by manually creating resources in the portal

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
- [x] I have updated the CHANGELOG
