### PR TITLE
Feature/add private dns zone virtual network link policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+## [3.1.0]
+
+### Added
+
+- Policy that automatically creates Private DNS Zone Virtual Network Links to a list of given Virtual Networks
+
 ## [3.0.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ As this repository uses Semantic versioning upgrading minor or patch releases sh
 ## Examples
 
 ### Basic
-First, the given template is adding this Module as `archetype_lib`. The Path of the library that is supposed to be summarized with the q.beyond library is set as the value of `cutomer_lib`.
+First, the given template is adding this Module as `archetype_lib`. The Path of the library that is supposed to be summarized with the q.beyond library is set as the value of `cutomer_lib`. 
 The output ´file_names´ can be used to manualy check whether all files that are supposed to be included in the merged library are included, as it outputs the names of all files that were added.
 The output of `merged_library` is supposed to be the input for the [CAF-Module](https://registry.terraform.io/modules/Azure/caf-enterprise-scale/azurerm/latest) for the parameter named `archetype_lib`
 
@@ -69,20 +69,21 @@ output "merged_library" {
 | <a name="output_file_names"></a> [file\_names](#output\_file\_names) | Outputs the files which were added to the library. |
 | <a name="output_merged_library"></a> [merged\_library](#output\_merged\_library) | Path to where the library containing both libraries can be found. This output can be given to the CAF-Module. |
 
-## Resource types
-| Type | Used |
-|------|-------|
-| [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | 1 |
-**`Used` only includes resource blocks.** `for_each` and `count` meta arguments, as well as resource blocks of modules are not considered.
-
+      ## Resource types
+      | Type | Used |
+      |------|-------|
+        | [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | 1 |
+      **`Used` only includes resource blocks.** `for_each` and `count` meta arguments, as well as resource blocks of modules are not considered.
+    
 ## Modules
 
 No modules.
 
-## Resources by Files
-### main.tf
-| Name | Type |
-|------|------|
-| [local_file.copied_files](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+        ## Resources by Files
+            ### main.tf
+            | Name | Type |
+            |------|------|
+                  | [local_file.copied_files](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+    
 <!-- END_TF_DOCS -->
 

--- a/archetypes/archetype_definition_qby_msp.json
+++ b/archetypes/archetype_definition_qby_msp.json
@@ -4,7 +4,8 @@
             "QBY-Deploy-DomainJoin",
             "QBY-Deploy-Update-Mgmt",
             "QBY-Deploy-VM-Backup",
-            "QBY-Deploy-VM-Monitoring"
+            "QBY-Deploy-VM-Monitoring",
+            "QBY-Deploy-Vnet-Links"
         ],
         "policy_definitions": [],
         "policy_set_definitions": [],

--- a/archetypes/archetype_definition_qby_root.json
+++ b/archetypes/archetype_definition_qby_root.json
@@ -139,7 +139,8 @@
             "QBY-Require-Tag",
             "QBY-Allowed-VM-SKUs",
             "QBY-Deploy-DependencyAgent",
-            "QBY-Deploy-VM-Backup"
+            "QBY-Deploy-VM-Backup",
+            "QBY-Deploy-Vnet-Links"
         ],
         "policy_set_definitions": [
             "Audit-UnusedResourcesCostOptimization",

--- a/policy_definitions/private_dns/policy_assignment_qby_virtual_network_links.tmpl.json
+++ b/policy_definitions/private_dns/policy_assignment_qby_virtual_network_links.tmpl.json
@@ -7,7 +7,7 @@
         "displayName": "Create Private DNS Zone Virtual Network Link to Virtual Networks if not available",
         "notScopes": [],
         "parameters": {},
-        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/QBY-Deploy-VM-Backup",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/QBY-Deploy-Vnet-Links",
         "nonComplianceMessages": [],
         "scope": "${current_scope_resource_id}",
         "enforcementMode": null

--- a/policy_definitions/private_dns/policy_assignment_qby_virtual_network_links.tmpl.json
+++ b/policy_definitions/private_dns/policy_assignment_qby_virtual_network_links.tmpl.json
@@ -1,0 +1,19 @@
+{
+    "name": "QBY-Deploy-Vnet-Links",
+    "type": "Microsoft.Authorization/policyAssignments",
+    "apiVersion": "2019-09-01",
+    "properties": {
+        "description": "Create Private DNS Zone Virtual Network Link to provided Virtual Networks if not available",
+        "displayName": "Create Private DNS Zone Virtual Network Link to Virtual Networks if not available",
+        "notScopes": [],
+        "parameters": {},
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/QBY-Deploy-VM-Backup",
+        "nonComplianceMessages": [],
+        "scope": "${current_scope_resource_id}",
+        "enforcementMode": null
+    },
+    "location": "${default_location}",
+    "identity": {
+        "type": "SystemAssigned"
+    }
+}

--- a/policy_definitions/private_dns/policy_definition_qby_virtual_network_links.json
+++ b/policy_definitions/private_dns/policy_definition_qby_virtual_network_links.json
@@ -1,0 +1,125 @@
+{
+    "name": "QBY-Deploy-Vnet-Links",
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "apiVersion": "2021-06-01",
+    "properties": {
+        "displayName": "Create Private DNS Zone Virtual Network Link to Virtual Networks if not available",
+        "description": "Create Private DNS Zone Virtual Network Link to Virtual Networks if not available",
+        "metadata": {
+            "category": "Network",
+            "version": "1.0.0"
+        },
+        "mode": "All",
+        "parameters": {
+            "virtualNetworkResourceId": {
+                "defaultValue": [],
+                "metadata": {
+                    "description": "Resource Ids of a vNet to link. The format must be: '/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Network/virtualNetworks/{virtual network name}",
+                    "displayName": "Vnet Resource IDs"
+                },
+                "type": "array"
+            },
+            "registrationEnabled": {
+                "defaultValue": false,
+                "metadata": {
+                    "description": "Enables automatic DNS registration in the zone for the linked vNet.",
+                    "displayName": "Enable Registration"
+                },
+                "type": "Boolean"
+            },
+            "effect": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "DeployIfNotExists, AuditIfNotExists or Disabled the execution of the Policy"
+                },
+                "allowedValues": [
+                    "DeployIfNotExists",
+                    "AuditIfNotExists",
+                    "Disabled"
+                ],
+                "defaultValue": "DeployIfNotExists"
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "equals": "Microsoft.Network/privateDnsZones",
+                        "field": "type"
+                    }
+                ]
+            },
+            "then": {
+                "details": {
+                    "existenceCondition": {
+                        "allOf": [
+                            {
+                                "equals": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+                                "field": "type"
+                            },
+                            {
+                                "in": "[parameters('virtualNetworkResourceId')]",
+                                "field": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/virtualNetwork.id"
+                            }
+                        ]
+                    },
+                    "deployment": {
+                        "properties": {
+                            "mode": "incremental",
+                            "parameters": {
+                                "privateDnsZoneName": {
+                                    "value": "[field('name')]"
+                                },
+                                "virtualNetworkResourceId": {
+                                    "value": "[parameters('virtualNetworkResourceId')]"
+                                },
+                                "registrationEnabled": {
+                                    "value": "[parameters('registrationEnabled')]"
+                                }
+                            },
+                            "template": {
+                                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                                "contentVersion": "1.0.0.0",
+                                "parameters": {
+                                    "privateDnsZoneName": {
+                                        "type": "String"
+                                    },
+                                    "virtualNetworkResourceId": {
+                                        "type": "array"
+                                    },
+                                    "registrationEnabled": {
+                                        "type": "bool"
+                                    }
+                                },
+                                "resources": [
+                                    {
+                                        "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+                                        "apiVersion": "2018-09-01",
+                                        "name": "[concat(parameters('privateDnsZoneName'),'/',concat(parameters('privateDnsZoneName'),'-', last(split(parameters('virtualNetworkResourceId')[copyIndex()],'/'))))]",
+                                        "location": "global",
+                                        "copy": {
+                                            "name": "vnetlink-counter",
+                                            "count": "[length(parameters('virtualNetworkResourceId'))]"
+                                        },
+                                        "properties": {
+                                            "registrationEnabled": "[parameters('registrationEnabled')]",
+                                            "virtualNetwork": {
+                                                "id": "[parameters('virtualNetworkResourceId')[copyIndex()]]"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "roleDefinitionIds": [
+                        "/providers/microsoft.authorization/roleDefinitions/b12aa53e-6015-4669-85d0-8515ebb3ae7f"
+                    ],
+                    "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks"
+                },
+                "effect": "[parameters('effect')]"
+            }
+        }
+    }
+}

--- a/policy_definitions/vmmonitoring/policy_set_definition_qby_deploy_vm_monitoring.tmpl.json
+++ b/policy_definitions/vmmonitoring/policy_set_definition_qby_deploy_vm_monitoring.tmpl.json
@@ -239,7 +239,7 @@
                 "policyDefinitionReferenceId": "Add system-assigned managed identity to enable Guest Configuration assignments on virtual machines with no identities",
                 "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/3cf2ab00-13f1-4d0c-8971-2ac904541a7e",
                 "parameters": {}
-            },
+            }%{ if linuxDCRs != [] || windowsDCRs != [] },%{ else }%{ endif }
             ${join(",", concat([for dcrId in linuxDCRs: jsonencode(
                 {
                     policyDefinitionReferenceId: "Configure Linux Machines to be associated with a Data Collection Rule ${regex("[^\\/]+$", dcrId)}",


### PR DESCRIPTION
# Description

Add policy for automatic creation of private dns zone virtual network links to specified virtual networks.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [x] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `3.0.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `3.1.0`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] Apply in test environment successful.
- [x] Remediation of new policy successful

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
- [x] I have updated the CHANGELOG
