### PR TITLE
remove spaces that break the function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+## [4.0.4]
+
+### Fixed
+
+- fixed mapping of update classifications
+
 ## [4.0.3]
 
 ### Fixed

--- a/policy_definitions/update_management/policy_definition_qby_deploy_updates.json
+++ b/policy_definitions/update_management/policy_definition_qby_deploy_updates.json
@@ -310,7 +310,7 @@
                   "recurEvery": "[concat(variables('splitSeverityGroup')[0], 'Month', ' ', variables('splitSeverityGroup')[1],' ', variables('splitSeverityGroup')[2])]",
                   "startTime": "[concat(substring(variables('splitSeverityGroup')[3], 0, 2), ':', substring(variables('splitSeverityGroup')[3], 2, 2)  )]",
                   "startDateTime": "[concat(parameters('startDate'), ' ', variables('startTime'))]",
-                  "updateClassification": "[map(range(0,length(replace(variables('splitSeverityGroup')[4],'X', ''))), lambda('i', variables('updateOptions')[substring(replace(variables('splitSeverityGroup')[4],'X',''), lambdaVariables('i'),1 )] )) ]                  ",
+                  "updateClassification": "[map(range(0,length(replace(variables('splitSeverityGroup')[4],'X', ''))), lambda('i', variables('updateOptions')[substring(replace(variables('splitSeverityGroup')[4],'X',''), lambdaVariables('i'),1 )] )) ]",
                   "rebootSetting": "[variables('rebootOptions')[variables('splitSeverityGroup')[5]]]",
                   "uniqueDeploymentName": "[concat('NestedDeploymentName-', uniqueString(deployment().name))]",
                   "scope": "[concat('Microsoft.Compute/virtualMachines', '/', parameters('vmName'))]",


### PR DESCRIPTION
# Description

The spaces caused the function to break. Instead of evaluating the string function, the whole function was inserted to the template.

As discussed in #(issue) we need to support xxx. Therefore we changed yyy.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `4.0.3`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `4.0.4`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] Definition was successfully used at a customer

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation
- [x] I have updated the CHANGELOG
