### PR TITLE
Feature/ama with proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0]
+
+### Added
+- changed the 6 default Microsoft policies to one big policy for AMA deployment
+- added proxy parameter to the new AMA policy
+- note: not providing the proxy parameter will result in the default AMA installation
+
+### Fixed
+- the virtual network resource id of the private dns assignment needs default param
 
 ## [5.0.0]
 

--- a/archetypes/archetype_definition_qby_root.json
+++ b/archetypes/archetype_definition_qby_root.json
@@ -140,6 +140,7 @@
             "QBY-Require-Tag",
             "QBY-Allowed-VM-SKUs",
             "QBY-Deploy-DependencyAgent",
+            "QBY-Deploy-AzureMonitorAgent",
             "QBY-Deploy-VM-Backup",
             "QBY-Deploy-Vnet-Links",
             "QBY-Allow-Subnet-NSG",

--- a/policy_definitions/private_dns/policy_assignment_qby_virtual_network_links.tmpl.json
+++ b/policy_definitions/private_dns/policy_assignment_qby_virtual_network_links.tmpl.json
@@ -6,7 +6,11 @@
         "description": "Create Private DNS Zone Virtual Network Link to specified Virtual Network for all private DNS zones.",
         "displayName": "Create Private DNS Zone Virtual Network Link to specified Virtual Network",
         "notScopes": [],
-        "parameters": {},
+        "parameters": {
+            "virtualNetworkResourceId": {
+                "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-resourcegroup-01/providers/Microsoft.Network/virtualNetworks/vnet-10-0-0-0-24-westeurope"
+            }
+        },
         "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/QBY-Deploy-Vnet-Links",
         "nonComplianceMessages": [],
         "scope": "${current_scope_resource_id}",

--- a/policy_definitions/private_dns/policy_definition_qby_virtual_network_links.json
+++ b/policy_definitions/private_dns/policy_definition_qby_virtual_network_links.json
@@ -16,7 +16,8 @@
                     "description": "Resource Id of a vNet to link. The format must be: '/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Network/virtualNetworks/{virtual network name}",
                     "displayName": "Vnet Resource ID"
                 },
-                "type": "string"
+                "type": "string",
+                "defaultValue": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-resourcegroup-01/providers/Microsoft.Network/virtualNetworks/vnet-10-0-0-0-24-westeurope"
             },
             "registrationEnabled": {
                 "defaultValue": false,

--- a/policy_definitions/private_dns/policy_definition_qby_virtual_network_links.json
+++ b/policy_definitions/private_dns/policy_definition_qby_virtual_network_links.json
@@ -16,8 +16,7 @@
                     "description": "Resource Id of a vNet to link. The format must be: '/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Network/virtualNetworks/{virtual network name}",
                     "displayName": "Vnet Resource ID"
                 },
-                "type": "string",
-                "defaultValue": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-resourcegroup-01/providers/Microsoft.Network/virtualNetworks/vnet-10-0-0-0-24-westeurope"
+                "type": "string"
             },
             "registrationEnabled": {
                 "defaultValue": false,

--- a/policy_definitions/vmmonitoring/policy_assignment_qby_deploy_vm_monitoring.tmpl.json
+++ b/policy_definitions/vmmonitoring/policy_assignment_qby_deploy_vm_monitoring.tmpl.json
@@ -30,6 +30,9 @@
       },
       "effect": {
         "value": "DeployIfNotExists"
+      },
+      "proxy": {
+        "value": "noproxy"
       }
     },
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policySetDefinitions/QBY-Deploy-VM-Monitoring",

--- a/policy_definitions/vmmonitoring/policy_definition_qby_deploy_azure_monitor_agent.json
+++ b/policy_definitions/vmmonitoring/policy_definition_qby_deploy_azure_monitor_agent.json
@@ -238,10 +238,10 @@
                                     }
                                 },
                                 "variables": {
-                                    "extensionName": "[concat('AzureMonitor', param('platform'), 'Agent')]",
+                                    "extensionName": "[concat('AzureMonitor', parameters('platform'), 'Agent')]",
                                     "extensionPublisher": "Microsoft.Azure.Monitor",
-                                    "extensionType": "[concat('AzureMonitor', param('platform'), 'Agent')]",
-                                    "extensionTypeHandlerVersion": "[if(equals(param('platform'),'Linux'),'1.29','1.1')]"
+                                    "extensionType": "[concat('AzureMonitor', parameters('platform'), 'Agent')]",
+                                    "extensionTypeHandlerVersion": "[if(equals(parameters('platform'),'Linux'),'1.29','1.1')]"
                                 },
                                 "resources": [
                                     {
@@ -290,6 +290,7 @@
                                             "type": "[variables('extensionType')]",
                                             "autoUpgradeMinorVersion": true,
                                             "enableAutomaticUpgrade": true,
+											"typeHandlerVersion": "[variables('extensionTypeHandlerVersion')]",
                                             "settings": {
                                                 "proxy": {
                                                     "auth": "false",
@@ -308,6 +309,7 @@
                                         "properties": {
                                             "publisher": "[variables('extensionPublisher')]",
                                             "type": "[variables('extensionType')]",
+											"typeHandlerVersion": "[variables('extensionTypeHandlerVersion')]",
                                             "autoUpgradeMinorVersion": true,
                                             "enableAutomaticUpgrade": true
                                         }
@@ -315,7 +317,7 @@
                                     {
                                         "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
                                         "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachineScaleSets'),not(equals(parameters('proxy'),'http://proxy.tld:8080')))]",
-                                        "name": "[concat(parameters('vmName'), '/', variables('vmExtensionName'))]",
+                                        "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
                                         "apiVersion": "2021-04-01",
                                         "location": "[parameters('location')]",
                                         "properties": {
@@ -334,15 +336,15 @@
                                     },
                                     {
                                         "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-                                        "typeHandlerVersion": "[variables('extensionTypeHandlerVersion')]",
                                         "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachineScaleSets'),equals(parameters('proxy'),'http://proxy.tld:8080'))]",
-                                        "name": "[concat(parameters('vmName'), '/', variables('vmExtensionName'))]",
+                                        "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
                                         "apiVersion": "2021-04-01",
                                         "location": "[parameters('location')]",
                                         "properties": {
                                             "publisher": "[variables('vmExtensionPublisher')]",
                                             "type": "[variables('vmExtensionType')]",
-                                            "autoUpgradeMinorVersion": true
+                                            "autoUpgradeMinorVersion": true,
+											"typeHandlerVersion": "[variables('extensionTypeHandlerVersion')]"
                                         }
                                     }
                                 ],

--- a/policy_definitions/vmmonitoring/policy_definition_qby_deploy_azure_monitor_agent.json
+++ b/policy_definitions/vmmonitoring/policy_definition_qby_deploy_azure_monitor_agent.json
@@ -1,0 +1,371 @@
+{
+    "name": "QBY-Deploy-AzureMonitorAgent",
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "properties": {
+        "displayName": "Deploy Azure Monitor agent",
+        "policyType": "Custom",
+        "mode": "Indexed",
+        "description": "Deploy Azure Monitor agent for Windows and Linux virtual machine scale sets and virtual machines if the agent is not installed.",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "Monitoring"
+        },
+        "parameters": {
+            "osTypeArc": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "OS type Arc machines included",
+                    "description": "Filter Arc machines by osType. None excludes arc machines. All includes any Arc machine."
+                },
+                "allowedValues": [
+                    "All",
+                    "Windows",
+                    "Linux",
+                    "None"
+                ],
+                "defaultValue": "All"
+            },
+            "osOffers": {
+                "type": "Array",
+                "metadata": {
+                    "displayName": "OS offers included",
+                    "description": "Include only offers of VMs and Scale sets like specified strings. Can contain * as wildcard. ['*'] includes any offer. Use an empty array [] to exclude VMs and scale sets."
+                },
+                "defaultValue": [
+                    "*"
+                ]
+            },
+            "osSKUs": {
+                "type": "Array",
+                "metadata": {
+                    "displayName": "OS SKUs included",
+                    "description": "Include only OS SKUs of VMs and Scale sets like specified strings. Can contain * as wildcard. ['*'] includes any SKU. Use an empty array [] to exclude VMs and scale sets."
+                },
+                "defaultValue": [
+                    "*"
+                ]
+            },
+            "effect": {
+                "type": "String",
+                "defaultValue": "DeployIfNotExists",
+                "allowedValues": [
+                    "AuditIfNotExist",
+                    "DeployIfNotExists",
+                    "Disabled"
+                ],
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "The effect determines what happens when the policy rule is evaluated to match."
+                }
+            },
+            "proxy": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Proxy URL",
+                    "description": "The URL of the proxy server used to reach Azure Monitor. Example values: 'http://10.0.0.125:8080', 'http://proxy.tld:8080'"
+                },
+                "defaultValue": "http://proxy.tld:8080"
+            }
+        },
+        "policyRule": {
+            "if": {
+                "anyOf": [
+                    {
+                        "allOf": [
+                            {
+                                "field": "type",
+                                "equals": "Microsoft.HybridCompute/machines"
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "field": "Microsoft.HybridCompute/imageOffer",
+                                        "like": "[concat(parameters('osTypeArc'), '*')]"
+                                    },
+                                    {
+                                        "value": "[parameters('osTypeArc')]",
+                                        "equals": "All"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "field": "type",
+                                        "equals": "Microsoft.Compute/virtualMachines"
+                                    },
+                                    {
+                                        "field": "type",
+                                        "equals": "Microsoft.Compute/virtualMachineScaleSets"
+                                    }
+                                ]
+                            },
+                            {
+                                "count": {
+                                    "name": "pattern",
+                                    "value": "[parameters('osOffers')]",
+                                    "where": {
+                                        "field": "Microsoft.Compute/ImageOffer",
+                                        "like": "[current('pattern')]"
+                                    }
+                                },
+                                "greater": 0
+                            },
+                            {
+                                "count": {
+                                    "name": "pattern",
+                                    "value": "[parameters('osSKUs')]",
+                                    "where": {
+                                        "field": "Microsoft.Compute/ImageSKU",
+                                        "like": "[current('pattern')]"
+                                    }
+                                },
+                                "greater": 0
+                            }
+                        ]
+                    }
+                ]
+            },
+            "then": {
+                "effect": "[parameters('effect')]",
+                "details": {
+                    "type": "[if(contains(createArray('Microsoft.Compute/virtualMachines', 'Microsoft.Compute/virtualMachineScaleSets', 'Microsoft.HybridCompute/machines'), field('type')), concat(field('type'), '/extensions'), 'Microsoft.Resources/resourceGroups')]",
+                    "evaluationDelay": "AfterProvisioningSuccess",
+                    "existenceCondition": {
+                        "anyOf": [
+                            {
+                                "allOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                                                "equals": "AzureMonitorLinuxAgent"
+                                            },
+                                            {
+                                                "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                                                "equals": "AzureMonitorWindowsAgent"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                                        "equals": "Microsoft.Azure.Monitor"
+                                    },
+                                    {
+                                        "field": "Microsoft.Compute/virtualMachines/extensions/provisioningState",
+                                        "equals": "Succeeded"
+                                    }
+                                ]
+                            },
+                            {
+                                "allOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "field": "Microsoft.HybridCompute/machines/extensions/type",
+                                                "equals": "AzureMonitorLinuxAgent"
+                                            },
+                                            {
+                                                "field": "Microsoft.HybridCompute/machines/extensions/type",
+                                                "equals": "AzureMonitorWindowsAgent"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "field": "Microsoft.HybridCompute/machines/extensions/publisher",
+                                        "equals": "Microsoft.Azure.Monitor"
+                                    },
+                                    {
+                                        "field": "Microsoft.HybridCompute/machines/extensions/provisioningState",
+                                        "equals": "Succeeded"
+                                    }
+                                ]
+                            },
+                            {
+                                "allOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "field": "Microsoft.Compute/virtualMachineScaleSets/extensions/type",
+                                                "equals": "AzureMonitorLinuxAgent"
+                                            },
+                                            {
+                                                "field": "Microsoft.Compute/virtualMachineScaleSets/extensions/type",
+                                                "equals": "AzureMonitorWindowsAgent"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "field": "Microsoft.Compute/virtualMachineScaleSets/extensions/publisher",
+                                        "equals": "Microsoft.Azure.Monitor"
+                                    },
+                                    {
+                                        "field": "Microsoft.Compute/virtualMachineScaleSets/extensions/provisioningState",
+                                        "equals": "Succeeded"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "roleDefinitionIds": [
+                        "/providers/microsoft.authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+                    ],
+                    "deployment": {
+                        "properties": {
+                            "mode": "incremental",
+                            "template": {
+                                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                                "contentVersion": "1.0.0.0",
+                                "parameters": {
+                                    "vmName": {
+                                        "type": "string"
+                                    },
+                                    "location": {
+                                        "type": "string"
+                                    },
+                                    "resourceType": {
+                                        "type": "string"
+                                    },
+                                    "platform": {
+                                        "type": "string"
+                                    },
+                                    "proxy": {
+                                        "type": "string"
+                                    }
+                                },
+                                "variables": {
+                                    "extensionName": "[concat('AzureMonitor', param('platform'), 'Agent')]",
+                                    "extensionPublisher": "Microsoft.Azure.Monitor",
+                                    "extensionType": "[concat('AzureMonitor', param('platform'), 'Agent')]"
+                                },
+                                "resources": [
+                                    {
+                                        "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
+                                        "type": "Microsoft.Compute/virtualMachines/extensions",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachines'),not(equals(parameters('proxy'),'http://proxy.tld:8080')))]",
+                                        "location": "[parameters('location')]",
+                                        "apiVersion": "2019-07-01",
+                                        "properties": {
+                                            "publisher": "[variables('extensionPublisher')]",
+                                            "type": "[variables('extensionType')]",
+                                            "autoUpgradeMinorVersion": true,
+                                            "enableAutomaticUpgrade": true,
+                                            "settings": {
+                                                "proxy": {
+                                                    "auth": "false",
+                                                    "mode": "application",
+                                                    "address": "[parameters('proxy')]"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
+                                        "type": "Microsoft.Compute/virtualMachines/extensions",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachines'),equals(parameters('proxy'),'http://proxy.tld:8080'))]",
+                                        "location": "[parameters('location')]",
+                                        "apiVersion": "2019-07-01",
+                                        "properties": {
+                                            "publisher": "[variables('extensionPublisher')]",
+                                            "type": "[variables('extensionType')]",
+                                            "autoUpgradeMinorVersion": true,
+                                            "enableAutomaticUpgrade": true
+                                        }
+                                    },
+                                    {
+                                        "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
+                                        "type": "Microsoft.HybridCompute/machines/extensions",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.HybridCompute/machines'),not(equals(parameters('proxy'),'http://proxy.tld:8080')))]",
+                                        "location": "[parameters('location')]",
+                                        "apiVersion": "2021-05-20",
+                                        "properties": {
+                                            "publisher": "[variables('extensionPublisher')]",
+                                            "type": "[variables('extensionType')]",
+                                            "autoUpgradeMinorVersion": true,
+                                            "enableAutomaticUpgrade": true,
+                                            "settings": {
+                                                "proxy": {
+                                                    "auth": "false",
+                                                    "mode": "application",
+                                                    "address": "[parameters('proxy')]"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
+                                        "type": "Microsoft.HybridCompute/machines/extensions",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.HybridCompute/machines'),equals(parameters('proxy'),'http://proxy.tld:8080'))]",
+                                        "location": "[parameters('location')]",
+                                        "apiVersion": "2021-05-20",
+                                        "properties": {
+                                            "publisher": "[variables('extensionPublisher')]",
+                                            "type": "[variables('extensionType')]",
+                                            "autoUpgradeMinorVersion": true,
+                                            "enableAutomaticUpgrade": true
+                                        }
+                                    },
+                                    {
+                                        "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachineScaleSets'),not(equals(parameters('proxy'),'http://proxy.tld:8080')))]",
+                                        "name": "[concat(parameters('vmName'), '/', variables('vmExtensionName'))]",
+                                        "apiVersion": "2021-04-01",
+                                        "location": "[parameters('location')]",
+                                        "properties": {
+                                            "publisher": "[variables('vmExtensionPublisher')]",
+                                            "type": "[variables('vmExtensionType')]",
+                                            "autoUpgradeMinorVersion": true,
+                                            "settings": {
+                                                "proxy": {
+                                                    "auth": "false",
+                                                    "mode": "application",
+                                                    "address": "[parameters('proxy')]"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachineScaleSets'),equals(parameters('proxy'),'http://proxy.tld:8080'))]",
+                                        "name": "[concat(parameters('vmName'), '/', variables('vmExtensionName'))]",
+                                        "apiVersion": "2021-04-01",
+                                        "location": "[parameters('location')]",
+                                        "properties": {
+                                            "publisher": "[variables('vmExtensionPublisher')]",
+                                            "type": "[variables('vmExtensionType')]",
+                                            "autoUpgradeMinorVersion": true
+                                        }
+                                    }
+                                ],
+                                "outputs": {
+                                    "policy": {
+                                        "type": "string",
+                                        "value": "[concat('Enabled extension for: ', parameters('vmName'))]"
+                                    }
+                                }
+                            },
+                            "parameters": {
+                                "vmName": {
+                                    "value": "[field('name')]"
+                                },
+                                "location": {
+                                    "value": "[field('location')]"
+                                },
+                                "resourceType": {
+                                    "value": "[field('type')]"
+                                },
+                                "platform": {
+                                    "value": "[if(or(contains(field('Microsoft.Compute/ImageOffer'), 'Windows'), equals(field('Microsoft.HybridCompute/machines/osName'), 'windows')), 'Windows', 'Linux')]"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/policy_definitions/vmmonitoring/policy_definition_qby_deploy_azure_monitor_agent.json
+++ b/policy_definitions/vmmonitoring/policy_definition_qby_deploy_azure_monitor_agent.json
@@ -64,7 +64,7 @@
                     "displayName": "Proxy URL",
                     "description": "The URL of the proxy server used to reach Azure Monitor. Example values: 'http://10.0.0.125:8080', 'http://proxy.tld:8080'"
                 },
-                "defaultValue": "http://proxy.tld:8080"
+                "defaultValue": "noproxy"
             }
         },
         "policyRule": {
@@ -247,7 +247,7 @@
                                     {
                                         "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
                                         "type": "Microsoft.Compute/virtualMachines/extensions",
-                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachines'),not(equals(parameters('proxy'),'http://proxy.tld:8080')))]",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachines'),not(equals(parameters('proxy'),'noproxy')))]",
                                         "location": "[parameters('location')]",
                                         "apiVersion": "2019-07-01",
                                         "properties": {
@@ -268,7 +268,7 @@
                                     {
                                         "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
                                         "type": "Microsoft.Compute/virtualMachines/extensions",
-                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachines'),equals(parameters('proxy'),'http://proxy.tld:8080'))]",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachines'),equals(parameters('proxy'),'noproxy'))]",
                                         "location": "[parameters('location')]",
                                         "apiVersion": "2019-07-01",
                                         "properties": {
@@ -282,7 +282,7 @@
                                     {
                                         "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
                                         "type": "Microsoft.HybridCompute/machines/extensions",
-                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.HybridCompute/machines'),not(equals(parameters('proxy'),'http://proxy.tld:8080')))]",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.HybridCompute/machines'),not(equals(parameters('proxy'),'noproxy')))]",
                                         "location": "[parameters('location')]",
                                         "apiVersion": "2021-05-20",
                                         "properties": {
@@ -303,7 +303,7 @@
                                     {
                                         "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
                                         "type": "Microsoft.HybridCompute/machines/extensions",
-                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.HybridCompute/machines'),equals(parameters('proxy'),'http://proxy.tld:8080'))]",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.HybridCompute/machines'),equals(parameters('proxy'),'noproxy'))]",
                                         "location": "[parameters('location')]",
                                         "apiVersion": "2021-05-20",
                                         "properties": {
@@ -316,7 +316,7 @@
                                     },
                                     {
                                         "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachineScaleSets'),not(equals(parameters('proxy'),'http://proxy.tld:8080')))]",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachineScaleSets'),not(equals(parameters('proxy'),'noproxy')))]",
                                         "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
                                         "apiVersion": "2021-04-01",
                                         "location": "[parameters('location')]",
@@ -336,7 +336,7 @@
                                     },
                                     {
                                         "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachineScaleSets'),equals(parameters('proxy'),'http://proxy.tld:8080'))]",
+                                        "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachineScaleSets'),equals(parameters('proxy'),'noproxy'))]",
                                         "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
                                         "apiVersion": "2021-04-01",
                                         "location": "[parameters('location')]",
@@ -367,6 +367,9 @@
                                 },
                                 "platform": {
                                     "value": "[if(or(contains(field('Microsoft.Compute/ImageOffer'), 'Windows'), equals(field('Microsoft.HybridCompute/machines/osName'), 'windows')), 'Windows', 'Linux')]"
+                                },
+                                "proxy": {
+                                    "value": "[parameters('proxy')]"
                                 }
                             }
                         }

--- a/policy_definitions/vmmonitoring/policy_definition_qby_deploy_azure_monitor_agent.json
+++ b/policy_definitions/vmmonitoring/policy_definition_qby_deploy_azure_monitor_agent.json
@@ -240,7 +240,8 @@
                                 "variables": {
                                     "extensionName": "[concat('AzureMonitor', param('platform'), 'Agent')]",
                                     "extensionPublisher": "Microsoft.Azure.Monitor",
-                                    "extensionType": "[concat('AzureMonitor', param('platform'), 'Agent')]"
+                                    "extensionType": "[concat('AzureMonitor', param('platform'), 'Agent')]",
+                                    "extensionTypeHandlerVersion": "[if(equals(param('platform'),'Linux'),'1.29','1.1')]"
                                 },
                                 "resources": [
                                     {
@@ -252,6 +253,7 @@
                                         "properties": {
                                             "publisher": "[variables('extensionPublisher')]",
                                             "type": "[variables('extensionType')]",
+                                            "typeHandlerVersion": "[variables('extensionTypeHandlerVersion')]",
                                             "autoUpgradeMinorVersion": true,
                                             "enableAutomaticUpgrade": true,
                                             "settings": {
@@ -272,6 +274,7 @@
                                         "properties": {
                                             "publisher": "[variables('extensionPublisher')]",
                                             "type": "[variables('extensionType')]",
+                                            "typeHandlerVersion": "[variables('extensionTypeHandlerVersion')]",
                                             "autoUpgradeMinorVersion": true,
                                             "enableAutomaticUpgrade": true
                                         }
@@ -318,6 +321,7 @@
                                         "properties": {
                                             "publisher": "[variables('vmExtensionPublisher')]",
                                             "type": "[variables('vmExtensionType')]",
+                                            "typeHandlerVersion": "[variables('extensionTypeHandlerVersion')]",
                                             "autoUpgradeMinorVersion": true,
                                             "settings": {
                                                 "proxy": {
@@ -330,6 +334,7 @@
                                     },
                                     {
                                         "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
+                                        "typeHandlerVersion": "[variables('extensionTypeHandlerVersion')]",
                                         "condition": "[and(equals(parameters('resourceType'), 'Microsoft.Compute/virtualMachineScaleSets'),equals(parameters('proxy'),'http://proxy.tld:8080'))]",
                                         "name": "[concat(parameters('vmName'), '/', variables('vmExtensionName'))]",
                                         "apiVersion": "2021-04-01",

--- a/policy_definitions/vmmonitoring/policy_set_definition_qby_deploy_vm_monitoring.tmpl.json
+++ b/policy_definitions/vmmonitoring/policy_set_definition_qby_deploy_vm_monitoring.tmpl.json
@@ -93,89 +93,35 @@
                     "displayName": "Effect",
                     "description": "The effect determines what happens when the policy rule is evaluated to match"
                 }
+            },
+            "proxy": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Proxy URL",
+                    "description": "The URL of the proxy server used to reach Azure Monitor. Example values: 'http://10.0.0.125:8080', 'http://proxy.tld:8080'"
+                },
+                "defaultValue": "http://proxy.tld:8080"
             }
         },
         "policyDefinitions": [
             {
-                "policyDefinitionReferenceId": "Configure Windows Arc-enabled machines to run Azure Monitor Agent",
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/94f686d6-9a24-4e19-91f1-de937dc171a4",
+                "policyDefinitionReferenceId": "Configure Azure Monitor agent on Windows & Linux virtual machines, virtual machine scale sets and Arc machines",
+                "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/QBY-Deploy-AzureMonitorAgent",
                 "parameters": {
-                    "effect": {
-                        "value": "[parameters('effect')]"
-                    }
-                },
-                "groupNames": []
-            },
-            {
-                "policyDefinitionReferenceId": "Configure Windows virtual machine scale sets to run Azure Monitor Agent using system-assigned managed identity",
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/4efbd9d8-6bc6-45f6-9be2-7fe9dd5d89ff",
-                "parameters": {
-                    "scopeToSupportedImages": {
-                        "value": "[parameters('scopeToSupportedImages')]"
+                    "osTypeArc": {
+                        "value": "[parameters('osTypeArc')]"
                     },
-                    "listOfWindowsImageIdToInclude": {
-                        "value": "[parameters('listOfWindowsImageIdToInclude')]"
+                    "osOffers": {
+                        "value": "[parameters('osOffers')]"
+                    },
+                    "osSKUs": {
+                        "value": "[parameters('osSKUs')]"
                     },
                     "effect": {
                         "value": "[parameters('effect')]"
-                    }
-                },
-                "groupNames": []
-            },
-            {
-                "policyDefinitionReferenceId": "Configure Windows virtual machines to run Azure Monitor Agent using system-assigned managed identity",
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ca817e41-e85a-4783-bc7f-dc532d36235e",
-                "parameters": {
-                    "scopeToSupportedImages": {
-                        "value": "[parameters('scopeToSupportedImages')]"
                     },
-                    "listOfWindowsImageIdToInclude": {
-                        "value": "[parameters('listOfWindowsImageIdToInclude')]"
-                    },
-                    "effect": {
-                        "value": "[parameters('effect')]"
-                    }
-                },
-                "groupNames": []
-            },
-            {
-                "policyDefinitionReferenceId": "Configure Linux Arc-enabled machines to run Azure Monitor Agent",
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/845857af-0333-4c5d-bbbc-6076697da122",
-                "parameters": {
-                    "effect": {
-                        "value": "[parameters('effect')]"
-                    }
-                },
-                "groupNames": []
-            },
-            {
-                "policyDefinitionReferenceId": "Configure Linux virtual machine scale sets to run Azure Monitor Agent with system-assigned managed identity-based authentication",
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/56a3e4f8-649b-4fac-887e-5564d11e8d3a",
-                "parameters": {
-                    "scopeToSupportedImages": {
-                        "value": "[parameters('scopeToSupportedImages')]"
-                    },
-                    "listOfLinuxImageIdToInclude": {
-                        "value": "[parameters('listOfLinuxImageIdToInclude')]"
-                    },
-                    "effect": {
-                        "value": "[parameters('effect')]"
-                    }
-                },
-                "groupNames": []
-            },
-            {
-                "policyDefinitionReferenceId": "Configure Linux virtual machines to run Azure Monitor Agent with system-assigned managed identity-based authentication",
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a4034bc6-ae50-406d-bf76-50f4ee5a7811",
-                "parameters": {
-                    "scopeToSupportedImages": {
-                        "value": "[parameters('scopeToSupportedImages')]"
-                    },
-                    "listOfLinuxImageIdToInclude": {
-                        "value": "[parameters('listOfLinuxImageIdToInclude')]"
-                    },
-                    "effect": {
-                        "value": "[parameters('effect')]"
+                    "proxy": {
+                        "value": "[parameters('proxy')]"
                     }
                 },
                 "groupNames": []

--- a/policy_definitions/vmmonitoring/policy_set_definition_qby_deploy_vm_monitoring.tmpl.json
+++ b/policy_definitions/vmmonitoring/policy_set_definition_qby_deploy_vm_monitoring.tmpl.json
@@ -100,7 +100,7 @@
                     "displayName": "Proxy URL",
                     "description": "The URL of the proxy server used to reach Azure Monitor. Example values: 'http://10.0.0.125:8080', 'http://proxy.tld:8080'"
                 },
-                "defaultValue": "http://proxy.tld:8080"
+                "defaultValue": "noproxy"
             }
         },
         "policyDefinitions": [


### PR DESCRIPTION
# Description

With this change, the Azure Monitor Agent will be installed by a custom policy, allowing for providing an optional proxy url.
Before this change, we used the 6 default policies by Microsoft for Linux/Windows, Arc/Scalesets/VMs.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [x] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `5.0.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `5.1.0`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- Policy Definition has been tested for win/linux, vms&scalesets, with/without proxy parameter
- CAF deployment has been tested in PCMS

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
- [x] I have updated the CHANGELOG
