### PR TITLE
Feature/audit vnet dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- note: an upcoming release should consider turning 5.2.0 into a major version
+by changing the DNS policy mode to `Deny`. This ensures that no VNet can be deployed
+without the Firewall as its primary DNS server
+
+## [5.2.0]
+
+### Added
+- added network security policy that enforces a particular DNS server
+(should be the firewall's ip address) on all vnets
+- note: this feature currently runs in `Audit` mode and will result in
+a breaking change once turned into a `Deny` policy
+
 ## [5.1.0]
 
 ### Added

--- a/policy_definitions/network_security/README.md
+++ b/policy_definitions/network_security/README.md
@@ -1,6 +1,6 @@
 # Network Security Policy Set
 
-This Network Security Policy Set forces NSG's to have a rule that denys all inbound traffic in Vnet. It also ensures all subnets to have an matching NSG with their Vnet in name associated.
+This Network Security Policy Set forces NSG's to have a rule that denys all inbound traffic in Vnet. It also ensures all subnets to have an matching NSG with their Vnet in name associated. Furthermore, it verifies that the DNS server assigned to a Vnet matches the ip of the firewall deployed.
 Exemptions are made for subnets that are named "AzureFirewallSubnet", "RouteServerSubnet", "GatewaySubnet" and "AzureBastionSubnet"
 
 The Rule that denys all inbound Traffic is checked based on following Properties:

--- a/policy_definitions/network_security/policy_assignment_qby_network_security.tmpl.json
+++ b/policy_definitions/network_security/policy_assignment_qby_network_security.tmpl.json
@@ -10,7 +10,14 @@
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policySetDefinitions/QBY-Network-Security",
     "scope": "${current_scope_resource_id}",
     "notScopes": ${jsonencode(notScopesForQbyNetworkSecurity)},
-    "parameters": {},
+    "parameters": {
+      "effect": {
+        "value": "Audit"
+      },
+      "DnsIp": {
+        "value": ""
+      }
+    },
     "nonComplianceMessages": [
       {
         "message": "NSG must contain a deny vNet Inbound Traffic Rule and a correct name",
@@ -23,6 +30,10 @@
       {
         "message": "vNet must be prefixed with 'vnet-', followed by the address space delimited by '-' and suffixed with the region. EG: vnet-10-0-0-0-16-eastus2",
         "policyDefinitionReferenceId": "Deny vNets with wrong name"
+      },
+      {
+        "message": "vNet must use the firewall IP as the primary DNS server",
+        "policyDefinitionReferenceId": "Allow only subnets with one DNS server matching the Firewall's IP address"
       }
     ]
   },

--- a/policy_definitions/network_security/policy_set_definition_qby_network_security.tmpl.json
+++ b/policy_definitions/network_security/policy_set_definition_qby_network_security.tmpl.json
@@ -11,7 +11,29 @@
             "version": "1.0.0",
             "category": "NetworkSecurity"
         },
-        "parameters": {},
+        "parameters": {
+            "effectForDNS": {
+                "type": "String",
+                "defaultValue": "Audit",
+                "allowedValues": [
+                    "Deny",
+                    "Audit",
+                    "Disabled"
+                ],
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "The effect determines what happens when the policy rule is evaluated to match"
+                }
+            },
+            "DnsIp": {
+                "type": "String",
+                "defaultValue": "",
+                "metadata": {
+                    "displayName": "DNS Server IP (should be the deployed firewall)",
+                    "description": "The DNS Server to forward all DNS requests from all VNets to - should be the IP of the deployed firewall"
+                }
+            }
+        },
         "policyDefinitions": [
             {
                 "policyDefinitionReferenceId": "Deny Network Security Groups without default deny rule",
@@ -24,6 +46,18 @@
             {
                 "policyDefinitionReferenceId": "Deny vNets with wrong name",
                 "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/QBY-Allow-Vnet-Name"
+            },
+            {
+                "policyDefinitionReferenceId": "Allow only subnets with one DNS server matching the Firewall's IP address",
+                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d8ebd9c5-3b41-41bc-845d-5069a808d3ea",
+                "parameters": {
+                    "effect": {
+                        "value": "[parameters('effectForDNS')]"
+                    },
+                    "servers": {
+                        "value": ["[parameters('DnsIp')]"]
+                    }
+                }
             }
         ],
         "policyDefinitionGroups": null


### PR DESCRIPTION
# Description

<!-- Please include a summary of changes and which issues are fixed -->
<!-- Example -->

vNets without the firewall as their primary DNS server should not be deployed at all. This PR adds a policy that audits if the DNS server of a vNet does not match the IP specified in the policy assignment's parameter. A future release may turn this into a `Deny` policy.

# Change overview (tick true):

- [x] This introduces backward incompatible changes
- [x] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `5.1.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `5.2.0`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [ ] Test in PCMS (ongoing)

# Checklist:

- [ ] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
- [x] I have updated the CHANGELOG
