### PR TITLE
Feature/deny bastion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0]
+
+### Added
+
+- added policy assignment that denies specific resource types unless they are deployed into a scope excluded via `notScopes`
+- resource type policy assignment denies bastion deployments by default
+
 ## [6.0.1]
 ### Fixed
 - removed broken policy set that was using old parameters

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,31 @@ This document includes guidelines what to do to upgrade to a new major version. 
 
 ## [Unreleased]
 
+## [6.1.0]
+
+### Resource types
+
+A new policy assignment `QBY-Deny-Resource-Types` denies resource types specified via `listOfResourceTypesNotAllowed`.
+The parameter `notScopes` can be used to specify scopes (subscriptions and resource groups only) where the policy
+does not take effect. Make sure to provide scopes with their full resource id and resource types with their provider.
+
+```terraform
+    "msp" = {
+      // ...
+      archetype_id = "qby_msp"
+      parameters = {
+        QBY-Deny-Resource-Types = {
+          listOfResourceTypesNotAllowed = [
+            "Microsoft.Network/bastionHost"
+          ]
+          notScopes = [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-resourcegroup-dev-01"
+          ]
+        }
+      }
+    }
+``` 
+
 ## [6.0.0]
 
 ### VM SKUs, Locations

--- a/archetypes/archetype_definition_qby_msp.json
+++ b/archetypes/archetype_definition_qby_msp.json
@@ -6,7 +6,8 @@
             "QBY-Deploy-VM-Backup",
             "QBY-Deploy-VM-Monitoring",
             "QBY-Deploy-Vnet-Links",
-            "QBY-Network-Security"
+            "QBY-Network-Security",
+            "QBY-Deny-Resource-Types"
         ],
         "policy_definitions": [],
         "policy_set_definitions": [],

--- a/archetypes/archetype_definition_qby_root.json
+++ b/archetypes/archetype_definition_qby_root.json
@@ -192,7 +192,8 @@
             "QBY-Allow-Vnet-Name",
             "QBY-Deny-Vnet-DNS",
             "QBY-Allowed-Locations-For-Resource-Groups",
-            "QBY-Allowed-Locations-For-Resources"
+            "QBY-Allowed-Locations-For-Resources",
+            "QBY-Deny-Resource-Types"
         ],
         "policy_set_definitions": [
             "Audit-UnusedResourcesCostOptimization",

--- a/policy_definitions/resource_types/policy_assignment_qby_deny_resource_types.tmpl.json
+++ b/policy_definitions/resource_types/policy_assignment_qby_deny_resource_types.tmpl.json
@@ -1,0 +1,25 @@
+{
+    "name": "QBY-Deny-Resource-Types",
+    "type": "Microsoft.Authorization/policyAssignments",
+    "apiVersion": "2019-09-01",
+    "properties": {
+        "description": "Deny the creation of resources with specific types, unless they are deployed to an excluded scope.",
+        "displayName": "Deny the creation of specific resource types.",
+        "notScopes": [],
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/QBY-Deny-Resource-Types",
+        "nonComplianceMessages": [],
+        "scope": "${current_scope_resource_id}",
+        "enforcementMode": null,
+        "parameters": {
+            "listOfResourceTypesNotAllowed": {
+                "value": [
+                    "Microsoft.Network/bastionHosts"
+                ]
+            }
+        }
+    },
+    "location": "${default_location}",
+    "identity": {
+        "type": "SystemAssigned"
+    }
+}

--- a/policy_definitions/resource_types/policy_assignment_qby_deny_resource_types.tmpl.json
+++ b/policy_definitions/resource_types/policy_assignment_qby_deny_resource_types.tmpl.json
@@ -12,9 +12,7 @@
         "enforcementMode": null,
         "parameters": {
             "listOfResourceTypesNotAllowed": {
-                "value": [
-                    "Microsoft.Network/bastionHosts"
-                ]
+                "value": []
             }
         }
     },

--- a/policy_definitions/resource_types/policy_definition_qby_deny_resource_types.json
+++ b/policy_definitions/resource_types/policy_definition_qby_deny_resource_types.json
@@ -1,0 +1,74 @@
+{
+    "name": "QBY-Deny-Resource-Types",
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "properties": {
+        "displayName": "Deny the creation of specific resource types.",
+        "policyType": "Custom",
+        "mode": "Indexed",
+        "description": "Deny the creation of resources with specific types, unless they are deployed to an excluded scope.",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "ResourceTypes"
+        },
+        "parameters": {
+            "listOfResourceTypesNotAllowed": {
+                "type": "Array",
+                "metadata": {
+                    "description": "The list of resource types that cannot be deployed.",
+                    "displayName": "Not allowed resource types",
+                    "strongType": "resourceTypes"
+                }
+            },
+            "notScopes": {
+                "type": "Array",
+                "metadata": {
+                    "description": "The list of scopes where this policy does not apply and resources can still be deployed to. Must be subscriptions or resource groups in their resource id format",
+                    "displayName": "Excluded scopes"
+                },
+                "defaultValue": []
+            },
+            "effect": {
+                "type": "String",
+                "defaultValue": "Deny",
+
+                "allowedValues": [
+                    "Audit",
+                    "Deny",
+                    "Disabled"
+                ],
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "The effect determines what happens when the policy rule is evaluated to match."
+                }
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "in": "[parameters('listOfResourceTypesNotAllowed')]"
+                    },
+                    {
+                        "value": "[field('type')]",
+                        "exists": true
+                    },
+                    {
+                        "count": {
+                            "value": "[parameters('notScopes')]",
+                            "name": "scope",
+                            "where": {
+                                "field": "id",
+                                "like": "[concat(current('scope'), '*')]"
+                            }
+                        },
+                        "equals": 0
+                    }
+                ]
+            },
+            "then": {
+                "effect": "[parameters('effect')]"
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of changes and which issues are fixed -->
<!-- Example -->

As discussed in #42, we need to stop people from randomly deploying bastions using the "Connect via Bastion" button in the Azure portal.

So this PR introduces a policy and policy assignment that denies all kinds of resource types specified in `listOfResourceTypesNotAllowed`. Exclusions are made for resources in specific scopes specified via `notScopes`.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [x] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `6.0.1`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `6.1.0`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] Policy definition has been tested in PCMS
- [x] Policy assignment looks very similar to our already working assignments
- [x] Archetype deployment in PCMS successful.

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation
- [x] I have updated the CHANGELOG
