### PR TITLE
feat(vmbackup): add `BackupPolicyDefaultLS` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.0]
+
+### Added
+- added "BackupPolicyDefaultLS" option to list of selectable backup policies `QBY-Deploy-VM-Backup.activeBackupPolicy`
+
+### Changed
+- `QBY-Deploy-VM-Backup.backupPolicyLogicalName` defaults to empty string "" now. Leaving it empty results in
+`QBY-Deploy-VM-Backup.activeBackupPolicy` being used, which, if used, has always been the old default parameter "QbyDefault". Hence no breaking change.
+
 ## [6.1.0]
 
 ### Added

--- a/policy_definitions/vmbackup/policy_definition_qby_deploy_vm_backup.json
+++ b/policy_definitions/vmbackup/policy_definition_qby_deploy_vm_backup.json
@@ -76,7 +76,8 @@
         "allowedValues": [
           "DefaultPolicy",
           "EnhancedPolicy",
-          "QbyDefault"
+          "QbyDefault",
+          "BackupPolicyDefaultLS"
         ],
         "defaultValue": "QbyDefault"
       }

--- a/policy_definitions/vmbackup/policy_definition_qby_deploy_vm_backup.json
+++ b/policy_definitions/vmbackup/policy_definition_qby_deploy_vm_backup.json
@@ -122,7 +122,7 @@
             "properties": {
               "mode": "incremental",
               "template": {
-                "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                 "contentVersion": "1.0.0.0",
                 "parameters": {
                   "vmName": {
@@ -146,9 +146,9 @@
                   "backupPolicyLogicalName": {
                     "type": "string",
                     "metadata": {
-                      "description": "Logical name of the custom backup policy that will be used (PascalCase). Defaults to QbyDefault"
+                      "description": "Logical name of the custom backup policy that will be used (PascalCase). If empty, the activeBackupPolicy parameter is being used"
                     },
-                    "defaultValue": "QbyDefault"
+                    "defaultValue": ""
                   },
                   "rgLogicalNameOverride": {
                     "type": "string",
@@ -173,8 +173,13 @@
                 },
                 "variables": {
                   "backupFabric": "Azure",
-                  "backupPolicy": "[concat('bkpol-', parameters('backupPolicyLogicalName'), '-vm')]",
-                  "activeBackupPolicy": "[if(equals(parameters('activeBackupPolicy'), 'QbyDefault'), variables('backupPolicy'), parameters('activeBackupPolicy'))]",
+                  "azurePolicies": [
+                    "DefaultPolicy",
+                    "EnhancedPolicy"
+                  ],
+                  "backupPolicyLogicalName": "[if(equals(parameters('backupPolicyLogicalName'), ''), parameters('activeBackupPolicy'), parameters('backupPolicyLogicalName'))]",
+                  "backupPolicy": "[concat('bkpol-', variables('backupPolicyLogicalName'), '-vm')]",
+                  "activeBackupPolicy": "[if(contains(variables('azurePolicies'), parameters('activeBackupPolicy')), parameters('activeBackupPolicy'), variables('backupPolicy'))]",
                   "v2VmType": "Microsoft.Compute/virtualMachines",
                   "v2VmContainer": "iaasvmcontainer;iaasvmcontainerv2;",
                   "v2Vm": "vm;iaasvmcontainerv2;",
@@ -231,6 +236,68 @@
                             }
                           },
                           {
+                            "condition": "[equals(parameters('activeBackupPolicy'), 'BackupPolicyDefaultLS')]",
+                            "name": "[concat(variables('vaultName'), '/', variables('backupPolicy'))]",
+                            "apiVersion": "2021-12-01",
+                            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+                            "location": "[parameters('location')]",
+                            "dependsOn": [
+                              "[resourceId(subscription().subscriptionId, variables('rgName'), 'Microsoft.RecoveryServices/vaults/', variables('vaultName'))]"
+                            ],
+                            "properties": {
+                              "backupManagementType": "AzureIaasVM",
+                              "policyType": "V2",
+                              "instantRpRetentionRangeInDays": "1",
+                              "schedulePolicy": {
+                                "schedulePolicyType": "SimpleSchedulePolicyV2",
+                                "scheduleRunFrequency": "Daily",
+                                "hourlySchedule": null,
+                                "dailySchedule": {
+                                  "scheduleRunTimes": [
+                                    "2025-07-04T03:00:00.000Z"
+                                  ]
+                                },
+                                "weeklySchedule": null
+                              },
+                              "timeZone": "W. Europe Standard Time",
+                              "retentionPolicy": {
+                                "retentionPolicyType": "LongTermRetentionPolicy",
+                                "dailySchedule": {
+                                  "retentionTimes": [
+                                    "2025-07-04T03:00:00.000Z"
+                                  ],
+                                  "retentionDuration": {
+                                    "count": 14,
+                                    "durationType": "Days"
+                                  }
+                                },
+                                "weeklySchedule": {
+                                  "daysOfTheWeek": [
+                                    "Sunday"
+                                  ],
+                                  "retentionTimes": [
+                                    "2025-07-04T03:00:00.000Z"
+                                  ],
+                                  "retentionDuration": {
+                                    "count": 1,
+                                    "durationType": "Weeks"
+                                  }
+                                },
+                                "monthlySchedule": null,
+                                "yearlySchedule": null
+                              },
+                              "instantRPDetails": {
+                                "azureBackupRGNamePrefix": "[take(variables('rgName'), sub(length(variables('rgName')), 1))]"
+                              },
+                              "tieringPolicy": {
+                                "ArchivedRP": {
+                                  "tieringMode": "DoNotTier"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "condition": "[equals(parameters('activeBackupPolicy'), 'QbyDefault')]",
                             "name": "[concat(variables('vaultName'), '/', variables('backupPolicy'))]",
                             "apiVersion": "2021-12-01",
                             "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
@@ -287,67 +354,6 @@
                               "instantRpRetentionRangeInDays": 6,
                               "timeZone": "UTC",
                               "protectedItemsCount": 0
-                            }
-                          },
-                          {
-                            "name": "[concat(variables('vaultName'), '/', 'BackupPolicyDefaultLS')]",
-                            "apiVersion": "2021-12-01",
-                            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
-                            "location": "[parameters('location')]",
-                            "dependsOn": [
-                              "[resourceId(subscription().subscriptionId, variables('rgName'), 'Microsoft.RecoveryServices/vaults/', variables('vaultName'))]"
-                            ],
-                            "properties": {
-                              "backupManagementType": "AzureIaasVM",
-                              "policyType": "V2",
-                              "instantRPDetails": {
-                                "azureBackupRGNamePrefix": "[take(variables('rgName'), sub(length(variables('rgName')), 1))]"
-                              },
-                              "schedulePolicy": {
-                                "policyType": "Full",
-                                "schedulePolicy": {
-                                  "schedulePolicyType": "SimpleSchedulePolicy",
-                                  "scheduleRunFrequency": "Daily",
-                                  "scheduleRunTimes": [
-                                    "2023-03-20T02:00:00Z"
-                                  ],
-                                  "scheduleWeeklyFrequency": 1
-                                },
-                                "retentionPolicy": {
-                                  "retentionPolicyType": "LongTermRetentionPolicy",
-                                  "dailySchedule": {
-                                    "retentionTimes": [
-                                      "2023-03-20T02:00:00Z"
-                                    ],
-                                    "retentionDuration": {
-                                      "count": 14,
-                                      "durationType": "Days"
-                                    }
-                                  },
-                                  "weeklySchedule": {
-                                    "daysOfTheWeek": [
-                                      "Monday"
-                                    ],
-                                    "retentionTimes": [
-                                      "2023-03-20T02:00:00Z"
-                                    ],
-                                    "retentionDuration": {
-                                      "count": 1,
-                                      "durationType": "Weeks"
-                                    }
-                                  }
-                                },
-                                "tieringPolicy": {
-                                  "ArchivedRP": {
-                                    "tieringMode": "DoNotTier",
-                                    "duration": 0,
-                                    "durationType": "Invalid"
-                                  }
-                                },
-                                "instantRpRetentionRangeInDays": 1,
-                                "timeZone": "UTC",
-                                "protectedItemsCount": 0
-                              }
                             }
                           }
                         ],

--- a/policy_definitions/vmbackup/policy_definition_qby_deploy_vm_backup.json
+++ b/policy_definitions/vmbackup/policy_definition_qby_deploy_vm_backup.json
@@ -55,9 +55,9 @@
         "type": "string",
         "metadata": {
           "displayName": "Backup Policy Logical Name",
-          "description": "Logical name of the custom backup policy that will be used (PascalCase)"
+          "description": "Logical name of the custom backup policy that will be used (PascalCase). If empty, the activeBackupPolicy parameter is being used"
         },
-        "defaultValue": "QbyDefault"
+        "defaultValue": ""
       },
       "rgLogicalNameOverride": {
         "type": "string",

--- a/policy_definitions/vmbackup/policy_definition_qby_deploy_vm_backup.json
+++ b/policy_definitions/vmbackup/policy_definition_qby_deploy_vm_backup.json
@@ -122,7 +122,7 @@
             "properties": {
               "mode": "incremental",
               "template": {
-                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
                 "contentVersion": "1.0.0.0",
                 "parameters": {
                   "vmName": {

--- a/policy_definitions/vmbackup/policy_definition_qby_deploy_vm_backup.json
+++ b/policy_definitions/vmbackup/policy_definition_qby_deploy_vm_backup.json
@@ -164,7 +164,8 @@
                     "allowedValues": [
                       "DefaultPolicy",
                       "EnhancedPolicy",
-                      "QbyDefault"
+                      "QbyDefault",
+                      "BackupPolicyDefaultLS"
                     ],
                     "defaultValue": "QbyDefault"
                   }
@@ -285,6 +286,67 @@
                               "instantRpRetentionRangeInDays": 6,
                               "timeZone": "UTC",
                               "protectedItemsCount": 0
+                            }
+                          },
+                          {
+                            "name": "[concat(variables('vaultName'), '/', 'BackupPolicyDefaultLS')]",
+                            "apiVersion": "2021-12-01",
+                            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+                            "location": "[parameters('location')]",
+                            "dependsOn": [
+                              "[resourceId(subscription().subscriptionId, variables('rgName'), 'Microsoft.RecoveryServices/vaults/', variables('vaultName'))]"
+                            ],
+                            "properties": {
+                              "backupManagementType": "AzureIaasVM",
+                              "policyType": "V2",
+                              "instantRPDetails": {
+                                "azureBackupRGNamePrefix": "[take(variables('rgName'), sub(length(variables('rgName')), 1))]"
+                              },
+                              "schedulePolicy": {
+                                "policyType": "Full",
+                                "schedulePolicy": {
+                                  "schedulePolicyType": "SimpleSchedulePolicy",
+                                  "scheduleRunFrequency": "Daily",
+                                  "scheduleRunTimes": [
+                                    "2023-03-20T02:00:00Z"
+                                  ],
+                                  "scheduleWeeklyFrequency": 1
+                                },
+                                "retentionPolicy": {
+                                  "retentionPolicyType": "LongTermRetentionPolicy",
+                                  "dailySchedule": {
+                                    "retentionTimes": [
+                                      "2023-03-20T02:00:00Z"
+                                    ],
+                                    "retentionDuration": {
+                                      "count": 14,
+                                      "durationType": "Days"
+                                    }
+                                  },
+                                  "weeklySchedule": {
+                                    "daysOfTheWeek": [
+                                      "Monday"
+                                    ],
+                                    "retentionTimes": [
+                                      "2023-03-20T02:00:00Z"
+                                    ],
+                                    "retentionDuration": {
+                                      "count": 1,
+                                      "durationType": "Weeks"
+                                    }
+                                  }
+                                },
+                                "tieringPolicy": {
+                                  "ArchivedRP": {
+                                    "tieringMode": "DoNotTier",
+                                    "duration": 0,
+                                    "durationType": "Invalid"
+                                  }
+                                },
+                                "instantRpRetentionRangeInDays": 1,
+                                "timeZone": "UTC",
+                                "protectedItemsCount": 0
+                              }
                             }
                           }
                         ],


### PR DESCRIPTION
# Description

Adds a "BackupPolicyDefaultLS" option to the list of selectable backup policies in `QBY-Deploy-VM-Backup.activeBackupPolicy`.

A little refactoring (changing parameter default values and adding conditions) allows for simple addition of new custom policies in the archetype library. Simply copy the backup policy resource definition, alter the condition to match the correct name, and set your desired values.

Note: `QBY-Deploy-VM-Backup.backupPolicyLogicalName` defaults to empty string "" now. Leaving it empty results in
`QBY-Deploy-VM-Backup.activeBackupPolicy` being used, which, if used, has always been the old default parameter "QbyDefault". Hence no breaking change.

<!-- Please include a summary of changes and which issues are fixed -->
<!-- Example -->

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [x] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `6.1.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `6.2.0`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] ARM deployment has been tested in PCMS
- [x] pre-release deployment of the archetype lib works in customer tenant

# Checklist:

- [ ] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation
- [x] I have updated the CHANGELOG
