### PR TITLE
Fix/deprecated policy

### DIFF
--- a/archetypes/archetype_definition_qby_root.json
+++ b/archetypes/archetype_definition_qby_root.json
@@ -226,7 +226,11 @@
             "Subscription-Owner"
         ],
         "archetype_config": {
-            "parameters": {},
+            "parameters": {
+                "Enforce-EncryptTransit_20241211": {
+                    "effect": "Deny"
+                }
+            },
             "access_control": {}
         }
     }

--- a/archetypes/archetype_definition_qby_root.json
+++ b/archetypes/archetype_definition_qby_root.json
@@ -210,7 +210,7 @@
             "Enforce-ACSB",
             "Enforce-ALZ-Decomm",
             "Enforce-ALZ-Sandbox",
-            "Enforce-EncryptTransit_20241211",
+            "Enforce-EncryptTransit",
             "Enforce-Guardrails-KeyVault",
             "QBY-Deploy-Update-Mgmt",
             "QBY-Deploy-VM-Monitoring",

--- a/archetypes/archetype_definition_qby_root.json
+++ b/archetypes/archetype_definition_qby_root.json
@@ -228,7 +228,8 @@
         "archetype_config": {
             "parameters": {
                 "Enforce-EncryptTransit_20241211": {
-                    "effect": "Deny"
+                    "Effect": "Deny",
+                    "defaultValue": "Deny"
                 }
             },
             "access_control": {}

--- a/archetypes/archetype_definition_qby_root.json
+++ b/archetypes/archetype_definition_qby_root.json
@@ -210,7 +210,7 @@
             "Enforce-ACSB",
             "Enforce-ALZ-Decomm",
             "Enforce-ALZ-Sandbox",
-            "Enforce-EncryptTransit_20241211",
+            "QBY-Enforce-EncryptTransit",
             "Enforce-Guardrails-KeyVault",
             "QBY-Deploy-Update-Mgmt",
             "QBY-Deploy-VM-Monitoring",
@@ -226,12 +226,7 @@
             "Subscription-Owner"
         ],
         "archetype_config": {
-            "parameters": {
-                "Enforce-EncryptTransit_20241211": {
-                    "Effect": "Deny",
-                    "defaultValue": "Deny"
-                }
-            },
+            "parameters": {},
             "access_control": {}
         }
     }

--- a/archetypes/archetype_definition_qby_root.json
+++ b/archetypes/archetype_definition_qby_root.json
@@ -210,7 +210,7 @@
             "Enforce-ACSB",
             "Enforce-ALZ-Decomm",
             "Enforce-ALZ-Sandbox",
-            "Enforce-EncryptTransit",
+            "Enforce-EncryptTransit_20241211",
             "Enforce-Guardrails-KeyVault",
             "QBY-Deploy-Update-Mgmt",
             "QBY-Deploy-VM-Monitoring",

--- a/policy_definitions/encryption/policy_set_definition_enforce-encrypttransit.json
+++ b/policy_definitions/encryption/policy_set_definition_enforce-encrypttransit.json
@@ -511,7 +511,7 @@
             "value": "[parameters('AppServiceHttpEffect')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Append-AppService-httpsonly",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-AppService-httpsonly",
         "policyDefinitionReferenceId": "AppServiceHttpEffect"
       },
       {
@@ -525,7 +525,7 @@
             "value": "[parameters('AppServiceminTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Append-AppService-latestTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-AppService-latestTLS",
         "policyDefinitionReferenceId": "AppServiceminTlsVersion"
       },
       {
@@ -558,7 +558,7 @@
             "value": "[parameters('APIAppServiceHttpsEffect')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceApiApp-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceApiApp-http",
         "policyDefinitionReferenceId": "APIAppServiceHttpsEffect"
       },
       {
@@ -569,7 +569,7 @@
             "value": "[parameters('FunctionServiceHttpsEffect')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceFunctionApp-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceFunctionApp-http",
         "policyDefinitionReferenceId": "FunctionServiceHttpsEffect"
       },
       {
@@ -580,7 +580,7 @@
             "value": "[parameters('WebAppServiceHttpsEffect')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceWebApp-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceWebApp-http",
         "policyDefinitionReferenceId": "WebAppServiceHttpsEffect"
       },
       {
@@ -605,7 +605,7 @@
             "value": "[parameters('MySQLminimalTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-MySQL-sslEnforcement",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-MySQL-sslEnforcement",
         "policyDefinitionReferenceId": "MySQLEnableSSLDeployEffect"
       },
       {
@@ -619,7 +619,7 @@
             "value": "[parameters('MySQLminimalTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-MySql-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-MySql-http",
         "policyDefinitionReferenceId": "MySQLEnableSSLEffect"
       },
       {
@@ -633,7 +633,7 @@
             "value": "[parameters('PostgreSQLminimalTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSQL-sslEnforcement",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSQL-sslEnforcement",
         "policyDefinitionReferenceId": "PostgreSQLEnableSSLDeployEffect"
       },
       {
@@ -647,7 +647,7 @@
             "value": "[parameters('PostgreSQLminimalTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-PostgreSql-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PostgreSql-http",
         "policyDefinitionReferenceId": "PostgreSQLEnableSSLEffect"
       },
       {
@@ -661,7 +661,7 @@
             "value": "[parameters('RedisMinTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Append-Redis-sslEnforcement",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-Redis-sslEnforcement",
         "policyDefinitionReferenceId": "RedisTLSDeployEffect"
       },
       {
@@ -672,7 +672,7 @@
             "value": "[parameters('RedisTLSDeployEffect')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Append-Redis-disableNonSslPort",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-Redis-disableNonSslPort",
         "policyDefinitionReferenceId": "RedisdisableNonSslPort"
       },
       {
@@ -686,7 +686,7 @@
             "value": "[parameters('RedisMinTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-Redis-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Redis-http",
         "policyDefinitionReferenceId": "RedisDenyhttps"
       },
       {
@@ -700,7 +700,7 @@
             "value": "[parameters('SQLManagedInstanceMinTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-SqlMi-minTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-SqlMi-minTLS",
         "policyDefinitionReferenceId": "SQLManagedInstanceTLSDeployEffect"
       },
       {
@@ -714,7 +714,7 @@
             "value": "[parameters('SQLManagedInstanceMinTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-SqlMi-minTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-SqlMi-minTLS",
         "policyDefinitionReferenceId": "SQLManagedInstanceTLSEffect"
       },
       {
@@ -728,7 +728,7 @@
             "value": "[parameters('SQLServerminTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-SQL-minTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-SQL-minTLS",
         "policyDefinitionReferenceId": "SQLServerTLSDeployEffect"
       },
       {
@@ -742,7 +742,7 @@
             "value": "[parameters('SQLServerminTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-Sql-minTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Sql-minTLS",
         "policyDefinitionReferenceId": "SQLServerTLSEffect"
       },
       {
@@ -756,7 +756,7 @@
             "value": "[parameters('StorageMinimumTlsVersion')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-Storage-sslEnforcement",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Storage-sslEnforcement",
         "policyDefinitionReferenceId": "StorageDeployHttpsEnabledEffect"
       },
       {
@@ -789,7 +789,7 @@
             "value": "[parameters('LogicAppTlsEffect')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-LogicApp-TLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-LogicApp-TLS",
         "policyDefinitionReferenceId": "Deploy-LogicApp-TLS"
       },
       {
@@ -800,7 +800,7 @@
             "value": "[parameters('logicAppHttpsEffect')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-LogicApps-Without-Https",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-LogicApps-Without-Https",
         "policyDefinitionReferenceId": "Deny-LogicApp-Without-Https"
       },
       {
@@ -899,7 +899,7 @@
             "value": "[parameters('eventHubMinTls')]"
           }
         },
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-EH-minTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-EH-minTLS",
         "policyDefinitionReferenceId": "Deny-EH-minTLS"
       },
       {

--- a/policy_definitions/encryption/policy_set_definition_enforce-encrypttransit.json
+++ b/policy_definitions/encryption/policy_set_definition_enforce-encrypttransit.json
@@ -1,0 +1,953 @@
+{
+  "name": "QBY-Enforce-EncryptTransit",
+  "properties": {
+    "description": "Choose either Deploy if not exist and append in combination with audit or Select Deny in the Policy effect. Deny polices shift left. Deploy if not exist and append enforce but can be changed, and because missing existence condition require then the combination of Audit.",
+    "displayName": "Deny or Deploy and append TLS requirements and SSL enforcement on resources without Encryption in transit",
+    "metadata": {
+      "alzCloudEnvironments": [
+        "AzureCloud",
+        "AzureChinaCloud",
+        "AzureUSGovernment"
+      ],
+      "category": "Encryption",
+      "replacesPolicy": "Enforce-EncryptTransit_20241211",
+      "source": "https://github.com/Azure/Enterprise-Scale/",
+      "version": "2.0.0"
+    },
+    "parameters": {
+      "AKSIngressHttpsOnlyEffect": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "metadata": {
+          "description": "This policy enforces HTTPS ingress in a Kubernetes cluster. This policy is generally available for Kubernetes Service (AKS), and preview for AKS Engine and Azure Arc enabled Kubernetes. For instructions on using this policy, visit https://aka.ms/kubepolicydoc.",
+          "displayName": "AKS Service. Enforce HTTPS ingress in Kubernetes cluster"
+        },
+        "type": "String"
+      },
+      "APIAppServiceHttpsEffect": {
+        "allowedValues": [
+          "Audit",
+          "Disabled",
+          "Deny"
+        ],
+        "defaultValue": "Audit",
+        "metadata": {
+          "description": "Choose Deny or Audit in combination with Append policy. Use of HTTPS ensures server/service authentication and protects data in transit from network layer eavesdropping attacks.",
+          "displayName": "App Service API App. API App should only be accessible over HTTPS. Choose Deny or Audit in combination with Append policy."
+        },
+        "type": "String"
+      },
+      "AppServiceHttpEffect": {
+        "allowedValues": [
+          "Append",
+          "Disabled"
+        ],
+        "defaultValue": "Append",
+        "metadata": {
+          "description": "Append the AppService sites object to ensure that min Tls version is set to required TLS version. Please note Append does not enforce compliance use then deny.",
+          "displayName": "App Service. Appends the AppService sites config WebApp, APIApp, Function App with TLS version selected below"
+        },
+        "type": "String"
+      },
+      "AppServiceTlsVersionEffect": {
+        "allowedValues": [
+          "Append",
+          "Disabled"
+        ],
+        "defaultValue": "Append",
+        "metadata": {
+          "description": "App Service. Appends the AppService sites object to ensure that  HTTPS only is enabled for  server/service authentication and protects data in transit from network layer eavesdropping attacks. Please note Append does not enforce compliance use then deny.",
+          "displayName": "App Service. Appends the AppService WebApp, APIApp, Function App to enable https only"
+        },
+        "type": "String"
+      },
+      "AppServiceminTlsVersion": {
+        "allowedValues": [
+          "1.3",
+          "1.2",
+          "1.1",
+          "1.0"
+        ],
+        "defaultValue": "1.2",
+        "metadata": {
+          "description": "App Service. Select version  minimum TLS version for a  Web App config to enforce",
+          "displayName": "App Service. Select version minimum TLS Web App config"
+        },
+        "type": "String"
+      },
+      "ContainerAppsHttpsOnlyEffect": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "metadata": {
+          "description": "Use of HTTPS ensures server/service authentication and protects data in transit from network layer eavesdropping attacks. Disabling 'allowInsecure' will result in the automatic redirection of requests from HTTP to HTTPS connections for container apps.",
+          "displayName": "Container Apps should only be accessible over HTTPS"
+        },
+        "type": "String"
+      },
+      "FunctionAppTlsEffect": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "metadata": {
+          "description": "App Service Function App. Periodically, newer versions are released for TLS either due to security flaws, include additional functionality, and enhance speed. Upgrade to the latest TLS version for Function apps to take advantage of security fixes, if any, and/or new functionalities of the latest version.",
+          "displayName": "App Service Function App. Configure Function apps to use the latest TLS version."
+        },
+        "type": "string"
+      },
+      "FunctionLatestTlsEffect": {
+        "allowedValues": [
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "AuditIfNotExists",
+        "metadata": {
+          "description": "Only Audit, deny not possible as it is a related resource. Upgrade to the latest TLS version.",
+          "displayName": "App Service Function App. Latest TLS version should be used in your Function App"
+        },
+        "type": "String"
+      },
+      "FunctionServiceHttpsEffect": {
+        "allowedValues": [
+          "Audit",
+          "Disabled",
+          "Deny"
+        ],
+        "defaultValue": "Audit",
+        "metadata": {
+          "description": "App Service Function App. Choose Deny or Audit in combination with Append policy. Use of HTTPS ensures server/service authentication and protects data in transit from network layer eavesdropping attacks.",
+          "displayName": "App Service Function App. Function App should only be accessible over HTTPS. Choose Deny or Audit in combination with Append policy."
+        },
+        "type": "String"
+      },
+      "LogicAppTlsEffect": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "type": "string"
+      },
+      "MySQLEnableSSLDeployEffect": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "metadata": {
+          "description": "Deploy a specific min TLS version requirement and enforce SSL on Azure Database for MySQL server. Enforce the Server to client applications using minimum version of Tls to secure the connection between your database server and your client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and your application. This configuration enforces that SSL is always enabled for accessing your database server.",
+          "displayName": "MySQL database servers. Deploy if not exist set minimum TLS version Azure Database for MySQL server"
+        },
+        "type": "String"
+      },
+      "MySQLEnableSSLEffect": {
+        "allowedValues": [
+          "Audit",
+          "Disabled",
+          "Deny"
+        ],
+        "defaultValue": "Audit",
+        "metadata": {
+          "description": "Azure Database for MySQL supports connecting your Azure Database for MySQL server to client applications using Secure Sockets Layer (SSL). Enforcing SSL connections between your database server and your client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and your application. This configuration enforces that SSL is always enabled for accessing your database server.",
+          "displayName": "MySQL database servers. Enforce SSL connection should be enabled for MySQL database servers"
+        },
+        "type": "String"
+      },
+      "MySQLminimalTlsVersion": {
+        "allowedValues": [
+          "TLS1_2",
+          "TLS1_0",
+          "TLS1_1",
+          "TLSEnforcementDisabled"
+        ],
+        "defaultValue": "TLS1_2",
+        "metadata": {
+          "description": "Select version  minimum TLS version Azure Database for MySQL server to enforce",
+          "displayName": "MySQL database servers. Select version minimum TLS for MySQL server"
+        },
+        "type": "String"
+      },
+      "PostgreSQLEnableSSLDeployEffect": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "metadata": {
+          "description": "Deploy a specific min TLS version requirement and enforce SSL on Azure Database for PostgreSQL server. Enforce the Server to client applications using minimum version of Tls to secure the connection between your database server and your client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and your application. This configuration enforces that SSL is always enabled for accessing your database server.",
+          "displayName": "PostgreSQL database servers. Deploy if not exist set minimum TLS version Azure Database for PostgreSQL server"
+        },
+        "type": "String"
+      },
+      "PostgreSQLEnableSSLEffect": {
+        "allowedValues": [
+          "Audit",
+          "Disabled",
+          "Deny"
+        ],
+        "defaultValue": "Audit",
+        "metadata": {
+          "description": "Azure Database for PostgreSQL supports connecting your Azure Database for PostgreSQL server to client applications using Secure Sockets Layer (SSL). Enforcing SSL connections between your database server and your client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and your application. This configuration enforces that SSL is always enabled for accessing your database server.",
+          "displayName": "PostgreSQL database servers. Enforce SSL connection should be enabled for PostgreSQL database servers"
+        },
+        "type": "String"
+      },
+      "PostgreSQLminimalTlsVersion": {
+        "allowedValues": [
+          "TLS1_2",
+          "TLS1_0",
+          "TLS1_1",
+          "TLSEnforcementDisabled"
+        ],
+        "defaultValue": "TLS1_2",
+        "metadata": {
+          "description": "PostgreSQL database servers. Select version  minimum TLS version Azure Database for MySQL server to enforce",
+          "displayName": "PostgreSQL database servers. Select version minimum TLS for MySQL server"
+        },
+        "type": "String"
+      },
+      "RedisMinTlsVersion": {
+        "allowedValues": [
+          "1.2",
+          "1.0",
+          "1.1"
+        ],
+        "defaultValue": "1.2",
+        "metadata": {
+          "description": "Select version  minimum TLS version for a Azure Cache for Redis to enforce",
+          "displayName": "Azure Cache for Redis.Select version minimum TLS for Azure Cache for Redis"
+        },
+        "type": "String"
+      },
+      "RedisTLSDeployEffect": {
+        "allowedValues": [
+          "Append",
+          "Disabled"
+        ],
+        "defaultValue": "Append",
+        "metadata": {
+          "description": "Deploy a specific min TLS version requirement and enforce SSL on Azure Cache for Redis. Enables secure server to client by enforce  minimal Tls Version to secure the connection between your database server and your client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and your application. This configuration enforces that SSL is always enabled for accessing your database server.",
+          "displayName": "Azure Cache for Redis. Deploy a specific min TLS version requirement and enforce SSL Azure Cache for Redis"
+        },
+        "type": "String"
+      },
+      "RedisTLSEffect": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Audit",
+        "metadata": {
+          "description": "Azure Cache for Redis. Audit enabling of only connections via SSL to Azure Cache for Redis. Use of secure connections ensures authentication between the server and the service and protects data in transit from network layer attacks such as man-in-the-middle, eavesdropping, and session-hijacking.",
+          "displayName": "Azure Cache for Redis. Only secure connections to your Azure Cache for Redis should be enabled"
+        },
+        "type": "String"
+      },
+      "SQLManagedInstanceMinTlsVersion": {
+        "allowedValues": [
+          "1.2",
+          "1.0",
+          "1.1"
+        ],
+        "defaultValue": "1.2",
+        "metadata": {
+          "description": "Select version  minimum TLS version for Azure Managed Instanceto to  enforce",
+          "displayName": "Azure Managed Instance.Select version minimum TLS for Azure Managed Instance"
+        },
+        "type": "String"
+      },
+      "SQLManagedInstanceTLSDeployEffect": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "metadata": {
+          "description": "Deploy a specific min TLS version requirement and enforce SSL on SQL servers. Enables secure server to client by enforce  minimal Tls Version to secure the connection between your database server and your client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and your application. This configuration enforces that SSL is always enabled for accessing your database server.",
+          "displayName": "Azure Managed Instance. Deploy a specific min TLS version requirement and enforce SSL on SQL servers"
+        },
+        "type": "String"
+      },
+      "SQLManagedInstanceTLSEffect": {
+        "allowedValues": [
+          "Audit",
+          "Disabled",
+          "Deny"
+        ],
+        "defaultValue": "Audit",
+        "metadata": {
+          "description": "Setting minimal TLS version to 1.2 improves security by ensuring your SQL Managed Instance can only be accessed from clients using TLS 1.2. Using versions of TLS less than 1.2 is not recommended since they have well documented security vulnerabilities.",
+          "displayName": "SQL Managed Instance should have the minimal TLS version of 1.2"
+        },
+        "type": "String"
+      },
+      "SQLServerTLSDeployEffect": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "metadata": {
+          "description": "Deploy a specific min TLS version requirement and enforce SSL on SQL servers. Enables secure server to client by enforce  minimal Tls Version to secure the connection between your database server and your client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and your application. This configuration enforces that SSL is always enabled for accessing your database server.",
+          "displayName": "Azure SQL Database. Deploy a specific min TLS version requirement and enforce SSL on SQL servers"
+        },
+        "type": "String"
+      },
+      "SQLServerTLSEffect": {
+        "allowedValues": [
+          "Audit",
+          "Disabled",
+          "Deny"
+        ],
+        "defaultValue": "Audit",
+        "metadata": {
+          "description": "Setting minimal TLS version to 1.2 improves security by ensuring your Azure SQL Database can only be accessed from clients using TLS 1.2. Using versions of TLS less than 1.2 is not recommended since they have well documented security vulnerabilities.",
+          "displayName": "Azure SQL Database should have the minimal TLS version of 1.2"
+        },
+        "type": "String"
+      },
+      "SQLServerminTlsVersion": {
+        "allowedValues": [
+          "1.2",
+          "1.0",
+          "1.1"
+        ],
+        "defaultValue": "1.2",
+        "metadata": {
+          "description": "Select version  minimum TLS version for Azure SQL Database to enforce",
+          "displayName": "Azure SQL Database.Select version minimum TLS for Azure SQL Database"
+        },
+        "type": "String"
+      },
+      "StorageDeployHttpsEnabledEffect": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "metadata": {
+          "description": "Audit requirement of Secure transfer in your storage account. Secure transfer is an option that forces your storage account to accept requests only from secure connections (HTTPS). Use of HTTPS ensures authentication between the server and the service and protects data in transit from network layer attacks such as man-in-the-middle, eavesdropping, and session-hijacking",
+          "displayName": "Azure Storage Account. Deploy Secure transfer to storage accounts should be enabled"
+        },
+        "type": "String"
+      },
+      "StorageMinimumTlsVersion": {
+        "allowedValues": [
+          "TLS1_2",
+          "TLS1_1",
+          "TLS1_0"
+        ],
+        "defaultValue": "TLS1_2",
+        "metadata": {
+          "description": "Select version  minimum TLS version on Azure Storage Account to enforce",
+          "displayName": "Storage Account select minimum TLS version"
+        },
+        "type": "String"
+      },
+      "WebAppServiceHttpsEffect": {
+        "allowedValues": [
+          "Audit",
+          "Disabled",
+          "Deny"
+        ],
+        "defaultValue": "Audit",
+        "metadata": {
+          "description": "Choose Deny or Audit in combination with Append policy. Use of HTTPS ensures server/service authentication and protects data in transit from network layer eavesdropping attacks.",
+          "displayName": "App Service Web App. Web Application should only be accessible over HTTPS. Choose Deny or Audit in combination with Append policy."
+        },
+        "type": "String"
+      },
+      "WebAppServiceLatestTlsEffect": {
+        "allowedValues": [
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "AuditIfNotExists",
+        "metadata": {
+          "description": "Only Audit, deny not possible as it is a related resource. Upgrade to the latest TLS version.",
+          "displayName": "App Service Web App. Latest TLS version should be used in your Web App"
+        },
+        "type": "String"
+      },
+      "appServiceAppSlotTls": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "type": "string"
+      },
+      "appServiceAppSlotsHttps": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "type": "string"
+      },
+      "appServiceAppsHttps": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "type": "string"
+      },
+      "appServiceAppsTls": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "type": "string"
+      },
+      "appServiceTls": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "type": "string"
+      },
+      "eventHubMinTls": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "type": "string"
+      },
+      "functionAppHttps": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "type": "string"
+      },
+      "functionAppSlotsHttps": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "type": "string"
+      },
+      "functionAppSlotsTls": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "type": "string"
+      },
+      "logicAppHttpsEffect": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "type": "string"
+      },
+      "sqlDbTls": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "type": "string"
+      },
+      "sqlManagedTlsVersion": {
+        "allowedValues": [
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Audit",
+        "type": "string"
+      },
+      "storageAccountsTls": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "type": "string"
+      },
+      "synapseTlsVersion": {
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny",
+        "type": "string"
+      }
+    },
+    "policyDefinitions": [
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('AppServiceHttpEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Append-AppService-httpsonly",
+        "policyDefinitionReferenceId": "AppServiceHttpEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('AppServiceTlsVersionEffect')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('AppServiceminTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Append-AppService-latestTLS",
+        "policyDefinitionReferenceId": "AppServiceminTlsVersion"
+      },
+      {
+        "definitionVersion": "2.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('FunctionLatestTlsEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/f9d614c5-c173-4d56-95a7-b4437057d193",
+        "policyDefinitionReferenceId": "FunctionLatestTlsEffect"
+      },
+      {
+        "definitionVersion": "2.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('WebAppServiceLatestTlsEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/f0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b",
+        "policyDefinitionReferenceId": "WebAppServiceLatestTlsEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('APIAppServiceHttpsEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceApiApp-http",
+        "policyDefinitionReferenceId": "APIAppServiceHttpsEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('FunctionServiceHttpsEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceFunctionApp-http",
+        "policyDefinitionReferenceId": "FunctionServiceHttpsEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('WebAppServiceHttpsEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceWebApp-http",
+        "policyDefinitionReferenceId": "WebAppServiceHttpsEffect"
+      },
+      {
+        "definitionVersion": "8.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('AKSIngressHttpsOnlyEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d",
+        "policyDefinitionReferenceId": "AKSIngressHttpsOnlyEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('MySQLEnableSSLDeployEffect')]"
+          },
+          "minimalTlsVersion": {
+            "value": "[parameters('MySQLminimalTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-MySQL-sslEnforcement",
+        "policyDefinitionReferenceId": "MySQLEnableSSLDeployEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('MySQLEnableSSLEffect')]"
+          },
+          "minimalTlsVersion": {
+            "value": "[parameters('MySQLminimalTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-MySql-http",
+        "policyDefinitionReferenceId": "MySQLEnableSSLEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('PostgreSQLEnableSSLDeployEffect')]"
+          },
+          "minimalTlsVersion": {
+            "value": "[parameters('PostgreSQLminimalTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSQL-sslEnforcement",
+        "policyDefinitionReferenceId": "PostgreSQLEnableSSLDeployEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('PostgreSQLEnableSSLEffect')]"
+          },
+          "minimalTlsVersion": {
+            "value": "[parameters('PostgreSQLminimalTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-PostgreSql-http",
+        "policyDefinitionReferenceId": "PostgreSQLEnableSSLEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('RedisTLSDeployEffect')]"
+          },
+          "minimumTlsVersion": {
+            "value": "[parameters('RedisMinTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Append-Redis-sslEnforcement",
+        "policyDefinitionReferenceId": "RedisTLSDeployEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('RedisTLSDeployEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Append-Redis-disableNonSslPort",
+        "policyDefinitionReferenceId": "RedisdisableNonSslPort"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('RedisTLSEffect')]"
+          },
+          "minimumTlsVersion": {
+            "value": "[parameters('RedisMinTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-Redis-http",
+        "policyDefinitionReferenceId": "RedisDenyhttps"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('SQLManagedInstanceTLSDeployEffect')]"
+          },
+          "minimalTlsVersion": {
+            "value": "[parameters('SQLManagedInstanceMinTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-SqlMi-minTLS",
+        "policyDefinitionReferenceId": "SQLManagedInstanceTLSDeployEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('SQLManagedInstanceTLSEffect')]"
+          },
+          "minimalTlsVersion": {
+            "value": "[parameters('SQLManagedInstanceMinTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-SqlMi-minTLS",
+        "policyDefinitionReferenceId": "SQLManagedInstanceTLSEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('SQLServerTLSDeployEffect')]"
+          },
+          "minimalTlsVersion": {
+            "value": "[parameters('SQLServerminTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-SQL-minTLS",
+        "policyDefinitionReferenceId": "SQLServerTLSDeployEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('SQLServerTLSEffect')]"
+          },
+          "minimalTlsVersion": {
+            "value": "[parameters('SQLServerminTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-Sql-minTLS",
+        "policyDefinitionReferenceId": "SQLServerTLSEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('StorageDeployHttpsEnabledEffect')]"
+          },
+          "minimumTlsVersion": {
+            "value": "[parameters('StorageMinimumTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-Storage-sslEnforcement",
+        "policyDefinitionReferenceId": "StorageDeployHttpsEnabledEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('ContainerAppsHttpsOnlyEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0e80e269-43a4-4ae9-b5bc-178126b8a5cb",
+        "policyDefinitionReferenceId": "ContainerAppsHttpsOnlyEffect"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('FunctionAppTlsEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1f01f1c7-539c-49b5-9ef4-d4ffa37d22e0",
+        "policyDefinitionReferenceId": "Dine-FunctionApp-Tls"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('LogicAppTlsEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-LogicApp-TLS",
+        "policyDefinitionReferenceId": "Deploy-LogicApp-TLS"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('logicAppHttpsEffect')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-LogicApps-Without-Https",
+        "policyDefinitionReferenceId": "Deny-LogicApp-Without-Https"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('functionAppSlotsTls')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/fa3a6357-c6d6-4120-8429-855577ec0063",
+        "policyDefinitionReferenceId": "Dine-Function-Apps-Slots-Tls"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('appServiceAppsTls')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ae44c1d1-0df2-4ca9-98fa-a3d3ae5b409d",
+        "policyDefinitionReferenceId": "Dine-AppService-Apps-Tls"
+      },
+      {
+        "definitionVersion": "4.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('appServiceAppsHttps')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a4af4a39-4135-47fb-b175-47fbdf85311d",
+        "policyDefinitionReferenceId": "Deny-AppService-Apps-Https"
+      },
+      {
+        "definitionVersion": "2.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('appServiceTls')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d6545c6b-dd9d-4265-91e6-0b451e2f1c50",
+        "policyDefinitionReferenceId": "Deny-AppService-Tls"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('appServiceAppSlotTls')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/014664e7-e348-41a3-aeb9-566e4ff6a9df",
+        "policyDefinitionReferenceId": "DINE-AppService-AppSlotTls"
+      },
+      {
+        "definitionVersion": "2.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('functionAppSlotsHttps')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/5e5dbe3f-2702-4ffc-8b1e-0cae008a5c71",
+        "policyDefinitionReferenceId": "Deny-FuncAppSlots-Https"
+      },
+      {
+        "definitionVersion": "5.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('functionAppHttps')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/6d555dd1-86f2-4f1c-8ed7-5abae7c6cbab",
+        "policyDefinitionReferenceId": "Deny-FunctionApp-Https"
+      },
+      {
+        "definitionVersion": "2.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('appServiceAppSlotsHttps')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ae1b9a8c-dfce-4605-bd91-69213b4a26fc",
+        "policyDefinitionReferenceId": "Deny-AppService-Slots-Https"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('eventHubMinTls')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deny-EH-minTLS",
+        "policyDefinitionReferenceId": "Deny-EH-minTLS"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('sqlManagedTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a8793640-60f7-487c-b5c3-1d37215905c4",
+        "policyDefinitionReferenceId": "Deny-Sql-Managed-Tls-Version"
+      },
+      {
+        "definitionVersion": "2.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('sqlDbTls')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/32e6bbec-16b6-44c2-be37-c5b672d103cf",
+        "policyDefinitionReferenceId": "Deny-Sql-Db-Tls"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('storageAccountsTls')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/fe83a0eb-a853-422d-aac2-1bffd182c5d0",
+        "policyDefinitionReferenceId": "Deny-Storage-Tls"
+      },
+      {
+        "definitionVersion": "1.*.*",
+        "groupNames": [],
+        "parameters": {
+          "effect": {
+            "value": "[parameters('synapseTlsVersion')]"
+          }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/cb3738a6-82a2-4a18-b87b-15217b9deff4",
+        "policyDefinitionReferenceId": "Deny-Synapse-Tls-Version"
+      }
+    ],
+    "policyType": "Custom"
+  },
+  "type": "Microsoft.Authorization/policySetDefinitions"
+}

--- a/policy_definitions/encryption/policy_set_definition_enforce-encrypttransit.json
+++ b/policy_definitions/encryption/policy_set_definition_enforce-encrypttransit.json
@@ -947,7 +947,8 @@
         "policyDefinitionReferenceId": "Deny-Synapse-Tls-Version"
       }
     ],
-    "policyType": "Custom"
+    "policyType": "Custom",
+    "policyDefinitionGroups": null
   },
   "type": "Microsoft.Authorization/policySetDefinitions"
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of changes and which issues are fixed -->

This PR fixes an error with the newest version of Azure libraries in which the policy set definition Enforce-EncryptTransit gives an error due to the condition not being in PascalCase

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [X] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `6.5.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `6.6.0`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [X] Apply of all examples was successfull
- [X] Tested in Mankiewicz and RKW

# Checklist:

- [X] I have run tests and documented them above
- [X] I have performed a self-review of my own code
- [X] I have updated the documentation
- [X] I have updated the CHANGELOG